### PR TITLE
Fix unexpected behavior in `client.read()` in one-to-many relations with no include params

### DIFF
--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_16/generated/company_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_16/generated/company_client.bal
@@ -105,7 +105,9 @@ public class CompanyStream {
                 return <persist:Error>error(streamValue.message());
             } else {
                 record {|Company value;|} nextRecord = {value: <Company>streamValue.value};
-                check (<persist:SQLClient>self.persistClient).getManyRelations(nextRecord.value, <CompanyRelations[]>self.include);
+                if self.include is CompanyRelations[] {
+                    check (<persist:SQLClient>self.persistClient).getManyRelations(nextRecord.value, <CompanyRelations[]>self.include);
+                }
                 return nextRecord;
             }
         } else {

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_17/generated/company_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_17/generated/company_client.bal
@@ -105,7 +105,9 @@ public class CompanyStream {
                 return <persist:Error>error(streamValue.message());
             } else {
                 record {|Company value;|} nextRecord = {value: <Company>streamValue.value};
-                check (<persist:SQLClient>self.persistClient).getManyRelations(nextRecord.value, <CompanyRelations[]>self.include);
+                if self.include is CompanyRelations[] {
+                    check (<persist:SQLClient>self.persistClient).getManyRelations(nextRecord.value, <CompanyRelations[]>self.include);
+                }
                 return nextRecord;
             }
         } else {

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_17/generated/employee_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_17/generated/employee_client.bal
@@ -122,7 +122,9 @@ public class EmployeeStream {
                 return <persist:Error>error(streamValue.message());
             } else {
                 record {|Employee value;|} nextRecord = {value: <Employee>streamValue.value};
-                check (<persist:SQLClient>self.persistClient).getManyRelations(nextRecord.value, <EmployeeRelations[]>self.include);
+                if self.include is EmployeeRelations[] {
+                    check (<persist:SQLClient>self.persistClient).getManyRelations(nextRecord.value, <EmployeeRelations[]>self.include);
+                }
                 return nextRecord;
             }
         } else {

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_20/generated/company_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_20/generated/company_client.bal
@@ -105,7 +105,9 @@ public class CompanyStream {
                 return <persist:Error>error(streamValue.message());
             } else {
                 record {|Company value;|} nextRecord = {value: <Company>streamValue.value};
-                check (<persist:SQLClient>self.persistClient).getManyRelations(nextRecord.value, <CompanyRelations[]>self.include);
+                if self.include is CompanyRelations[] {
+                    check (<persist:SQLClient>self.persistClient).getManyRelations(nextRecord.value, <CompanyRelations[]>self.include);
+                }
                 return nextRecord;
             }
         } else {

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_20/generated/employee_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_20/generated/employee_client.bal
@@ -122,7 +122,9 @@ public class EmployeeStream {
                 return <persist:Error>error(streamValue.message());
             } else {
                 record {|Employee value;|} nextRecord = {value: <Employee>streamValue.value};
-                check (<persist:SQLClient>self.persistClient).getManyRelations(nextRecord.value, <EmployeeRelations[]>self.include);
+                if self.include is EmployeeRelations[] {
+                    check (<persist:SQLClient>self.persistClient).getManyRelations(nextRecord.value, <EmployeeRelations[]>self.include);
+                }
                 return nextRecord;
             }
         } else {

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_28/generated/company_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_28/generated/company_client.bal
@@ -105,7 +105,9 @@ public class CompanyStream {
                 return <persist:Error>error(streamValue.message());
             } else {
                 record {|Company value;|} nextRecord = {value: <Company>streamValue.value};
-                check (<persist:SQLClient>self.persistClient).getManyRelations(nextRecord.value, <CompanyRelations[]>self.include);
+                if self.include is CompanyRelations[] {
+                    check (<persist:SQLClient>self.persistClient).getManyRelations(nextRecord.value, <CompanyRelations[]>self.include);
+                }
                 return nextRecord;
             }
         } else {

--- a/persist-cli/src/main/java/io/ballerina/persist/nodegenerator/BalSyntaxConstants.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/nodegenerator/BalSyntaxConstants.java
@@ -125,6 +125,7 @@ public class BalSyntaxConstants {
             "return <persist:Error>error(streamValue.message());";
     public static final String NEXT_STREAM_ELSE_STATEMENT = "record {|%s value;|} nextRecord = " +
             "{value: <%s>streamValue.value};";
+    public static final String RELATION_ENUM_ARRAY_CHECK = "self.include is %sRelations[]";
     public static final String CLOSE_STREAM_STATEMENT = "sql:Error? e = anydataStream.close();";
 
     public static final String CONFIGURABLE_PORT = "configurable int port = ?;";

--- a/persist-cli/src/main/java/io/ballerina/persist/nodegenerator/BalSyntaxGenerator.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/nodegenerator/BalSyntaxGenerator.java
@@ -878,8 +878,11 @@ public class BalSyntaxGenerator {
         streamValueErrorCheck.addElseStatement(NodeParser.parseStatement(String.format(
                 BalSyntaxConstants.NEXT_STREAM_ELSE_STATEMENT, entity.getEntityName(), entity.getEntityName())));
         if (hasManyRelation) {
-            streamValueErrorCheck.addElseStatement(NodeParser.parseStatement(String.format(GET_MANY_RELATIONS,
+            IfElse clientRelationsCheck = new IfElse(NodeParser.parseExpression(String.format(
+                    BalSyntaxConstants.RELATION_ENUM_ARRAY_CHECK, entity.getEntityName())));
+            clientRelationsCheck.addIfStatement(NodeParser.parseStatement(String.format(GET_MANY_RELATIONS,
                     className)));
+            streamValueErrorCheck.addElseStatement(clientRelationsCheck.getIfElseStatementNode());
         }
         streamValueErrorCheck.addElseStatement(NodeParser.parseStatement(BalSyntaxConstants.RETURN_NEXT_RECORD));
         streamValueNilCheck.addElseBody(streamValueErrorCheck);


### PR DESCRIPTION
## Purpose

Fixes: [3922](https://github.com/ballerina-platform/ballerina-standard-library/issues/3922)

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
