### PR TITLE
Add backticks to tablename and column name in the sql script

### DIFF
--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_1/generated/foo/foo_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_1/generated/foo/foo_db_script.sql
@@ -3,44 +3,44 @@
 -- This file is an auto-generated file by Ballerina persistence layer for foo.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Workspace;
-DROP TABLE IF EXISTS Employee;
-DROP TABLE IF EXISTS Building;
-DROP TABLE IF EXISTS Department;
+DROP TABLE IF EXISTS `Workspace`;
+DROP TABLE IF EXISTS `Employee`;
+DROP TABLE IF EXISTS `Building`;
+DROP TABLE IF EXISTS `Department`;
 
-CREATE TABLE Department (
-	deptNo VARCHAR(191) NOT NULL,
-	deptName VARCHAR(191) NOT NULL,
-	PRIMARY KEY(deptNo)
+CREATE TABLE `Department` (
+	`deptNo` VARCHAR(191) NOT NULL,
+	`deptName` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`deptNo`)
 );
 
-CREATE TABLE Building (
-	buildingCode VARCHAR(191) NOT NULL,
-	city VARCHAR(191) NOT NULL,
-	state VARCHAR(191) NOT NULL,
-	country VARCHAR(191) NOT NULL,
-	postalCode VARCHAR(191) NOT NULL,
-	PRIMARY KEY(buildingCode)
+CREATE TABLE `Building` (
+	`buildingCode` VARCHAR(191) NOT NULL,
+	`city` VARCHAR(191) NOT NULL,
+	`state` VARCHAR(191) NOT NULL,
+	`country` VARCHAR(191) NOT NULL,
+	`postalCode` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`buildingCode`)
 );
 
-CREATE TABLE Employee (
-	empNo VARCHAR(191) NOT NULL,
-	firstName VARCHAR(191) NOT NULL,
-	lastName VARCHAR(191) NOT NULL,
-	birthDate DATE NOT NULL,
-	gender VARCHAR(191) NOT NULL,
-	hireDate DATE NOT NULL,
-	departmentDeptNo VARCHAR(191) NOT NULL,
-	CONSTRAINT FK_EMPLOYEE_DEPARTMENT FOREIGN KEY(departmentDeptNo) REFERENCES Department(deptNo),
-	PRIMARY KEY(empNo)
+CREATE TABLE `Employee` (
+	`empNo` VARCHAR(191) NOT NULL,
+	`firstName` VARCHAR(191) NOT NULL,
+	`lastName` VARCHAR(191) NOT NULL,
+	`birthDate` DATE NOT NULL,
+	`gender` VARCHAR(191) NOT NULL,
+	`hireDate` DATE NOT NULL,
+	`departmentDeptNo` VARCHAR(191) NOT NULL,
+	CONSTRAINT FK_EMPLOYEE_DEPARTMENT FOREIGN KEY(`departmentDeptNo`) REFERENCES `Department`(`deptNo`),
+	PRIMARY KEY(`empNo`)
 );
 
-CREATE TABLE Workspace (
-	workspaceId VARCHAR(191) NOT NULL,
-	workspaceType VARCHAR(191) NOT NULL,
-	buildingBuildingCode VARCHAR(191) NOT NULL,
-	CONSTRAINT FK_WORKSPACE_BUILDING FOREIGN KEY(buildingBuildingCode) REFERENCES Building(buildingCode),
-	employeeEmpNo VARCHAR(191) UNIQUE NOT NULL,
-	CONSTRAINT FK_WORKSPACE_EMPLOYEE FOREIGN KEY(employeeEmpNo) REFERENCES Employee(empNo),
-	PRIMARY KEY(workspaceId)
+CREATE TABLE `Workspace` (
+	`workspaceId` VARCHAR(191) NOT NULL,
+	`workspaceType` VARCHAR(191) NOT NULL,
+	`buildingBuildingCode` VARCHAR(191) NOT NULL,
+	CONSTRAINT FK_WORKSPACE_BUILDING FOREIGN KEY(`buildingBuildingCode`) REFERENCES `Building`(`buildingCode`),
+	`employeeEmpNo` VARCHAR(191) UNIQUE NOT NULL,
+	CONSTRAINT FK_WORKSPACE_EMPLOYEE FOREIGN KEY(`employeeEmpNo`) REFERENCES `Employee`(`empNo`),
+	PRIMARY KEY(`workspaceId`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_11/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_11/generated/entities/entities_db_script.sql
@@ -3,14 +3,14 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS MedicalNeed;
+DROP TABLE IF EXISTS `MedicalNeed`;
 
-CREATE TABLE MedicalNeed (
-	needId INT NOT NULL,
-	itemId INT NOT NULL,
-	beneficiaryId INT NOT NULL,
-	period DATETIME NOT NULL,
-	urgency VARCHAR(191) NOT NULL,
-	quantity INT NOT NULL,
-	PRIMARY KEY(needId)
+CREATE TABLE `MedicalNeed` (
+	`needId` INT NOT NULL,
+	`itemId` INT NOT NULL,
+	`beneficiaryId` INT NOT NULL,
+	`period` DATETIME NOT NULL,
+	`urgency` VARCHAR(191) NOT NULL,
+	`quantity` INT NOT NULL,
+	PRIMARY KEY(`needId`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_13/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_13/generated/entities/entities_db_script.sql
@@ -3,30 +3,30 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Profile;
-DROP TABLE IF EXISTS User;
-DROP TABLE IF EXISTS MultipleAssociations;
+DROP TABLE IF EXISTS `Profile`;
+DROP TABLE IF EXISTS `User`;
+DROP TABLE IF EXISTS `MultipleAssociations`;
 
-CREATE TABLE MultipleAssociations (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	PRIMARY KEY(id)
+CREATE TABLE `MultipleAssociations` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE User (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	multipleassociationsId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_USER_MULTIPLEASSOCIATIONS FOREIGN KEY(multipleassociationsId) REFERENCES MultipleAssociations(id),
-	PRIMARY KEY(id)
+CREATE TABLE `User` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`multipleassociationsId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_USER_MULTIPLEASSOCIATIONS FOREIGN KEY(`multipleassociationsId`) REFERENCES `MultipleAssociations`(`id`),
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Profile (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	userId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_PROFILE_USER FOREIGN KEY(userId) REFERENCES User(id),
-	multipleassociationsId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_PROFILE_MULTIPLEASSOCIATIONS FOREIGN KEY(multipleassociationsId) REFERENCES MultipleAssociations(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Profile` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`userId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_PROFILE_USER FOREIGN KEY(`userId`) REFERENCES `User`(`id`),
+	`multipleassociationsId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_PROFILE_MULTIPLEASSOCIATIONS FOREIGN KEY(`multipleassociationsId`) REFERENCES `MultipleAssociations`(`id`),
+	PRIMARY KEY(`id`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_16/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_16/generated/entities/entities_db_script.sql
@@ -3,19 +3,19 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Employee;
-DROP TABLE IF EXISTS Company;
+DROP TABLE IF EXISTS `Employee`;
+DROP TABLE IF EXISTS `Company`;
 
-CREATE TABLE Company (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	PRIMARY KEY(id)
+CREATE TABLE `Company` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Employee (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	companyId INT NOT NULL,
-	CONSTRAINT FK_EMPLOYEE_COMPANY FOREIGN KEY(companyId) REFERENCES Company(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Employee` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`companyId` INT NOT NULL,
+	CONSTRAINT FK_EMPLOYEE_COMPANY FOREIGN KEY(`companyId`) REFERENCES `Company`(`id`),
+	PRIMARY KEY(`id`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_17/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_17/generated/entities/entities_db_script.sql
@@ -3,28 +3,28 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Vehicle;
-DROP TABLE IF EXISTS Employee;
-DROP TABLE IF EXISTS Company;
+DROP TABLE IF EXISTS `Vehicle`;
+DROP TABLE IF EXISTS `Employee`;
+DROP TABLE IF EXISTS `Company`;
 
-CREATE TABLE Company (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	PRIMARY KEY(id)
+CREATE TABLE `Company` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Employee (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	companyId INT NOT NULL,
-	CONSTRAINT FK_EMPLOYEE_COMPANY FOREIGN KEY(companyId) REFERENCES Company(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Employee` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`companyId` INT NOT NULL,
+	CONSTRAINT FK_EMPLOYEE_COMPANY FOREIGN KEY(`companyId`) REFERENCES `Company`(`id`),
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Vehicle (
-	model INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	employeeId INT NOT NULL,
-	CONSTRAINT FK_VEHICLE_EMPLOYEE FOREIGN KEY(employeeId) REFERENCES Employee(id),
-	PRIMARY KEY(model)
+CREATE TABLE `Vehicle` (
+	`model` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`employeeId` INT NOT NULL,
+	CONSTRAINT FK_VEHICLE_EMPLOYEE FOREIGN KEY(`employeeId`) REFERENCES `Employee`(`id`),
+	PRIMARY KEY(`model`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_19/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_19/generated/entities/entities_db_script.sql
@@ -3,30 +3,30 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Profile;
-DROP TABLE IF EXISTS User;
-DROP TABLE IF EXISTS MultipleAssociations;
+DROP TABLE IF EXISTS `Profile`;
+DROP TABLE IF EXISTS `User`;
+DROP TABLE IF EXISTS `MultipleAssociations`;
 
-CREATE TABLE MultipleAssociations (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	PRIMARY KEY(id)
+CREATE TABLE `MultipleAssociations` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE User (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	multipleassociationsId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_USER_MULTIPLEASSOCIATIONS FOREIGN KEY(multipleassociationsId) REFERENCES MultipleAssociations(id),
-	PRIMARY KEY(id)
+CREATE TABLE `User` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`multipleassociationsId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_USER_MULTIPLEASSOCIATIONS FOREIGN KEY(`multipleassociationsId`) REFERENCES `MultipleAssociations`(`id`),
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Profile (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	userId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_PROFILE_USER FOREIGN KEY(userId) REFERENCES User(id),
-	multipleassociationsId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_PROFILE_MULTIPLEASSOCIATIONS FOREIGN KEY(multipleassociationsId) REFERENCES MultipleAssociations(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Profile` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`userId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_PROFILE_USER FOREIGN KEY(`userId`) REFERENCES `User`(`id`),
+	`multipleassociationsId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_PROFILE_MULTIPLEASSOCIATIONS FOREIGN KEY(`multipleassociationsId`) REFERENCES `MultipleAssociations`(`id`),
+	PRIMARY KEY(`id`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_2/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_2/generated/entities/entities_db_script.sql
@@ -3,23 +3,23 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS MedicalNeed;
-DROP TABLE IF EXISTS MedicalItem;
+DROP TABLE IF EXISTS `MedicalNeed`;
+DROP TABLE IF EXISTS `MedicalItem`;
 
-CREATE TABLE MedicalItem (
-	itemId INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	type VARCHAR(191) NOT NULL,
-	unit VARCHAR(191) NOT NULL,
-	PRIMARY KEY(itemId)
+CREATE TABLE `MedicalItem` (
+	`itemId` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`type` VARCHAR(191) NOT NULL,
+	`unit` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`itemId`)
 );
 
-CREATE TABLE MedicalNeed (
-	needId INT NOT NULL,
-	itemId INT NOT NULL,
-	beneficiaryId INT NOT NULL,
-	period DATETIME NOT NULL,
-	urgency VARCHAR(191) NOT NULL,
-	quantity INT NOT NULL,
-	PRIMARY KEY(needId)
+CREATE TABLE `MedicalNeed` (
+	`needId` INT NOT NULL,
+	`itemId` INT NOT NULL,
+	`beneficiaryId` INT NOT NULL,
+	`period` DATETIME NOT NULL,
+	`urgency` VARCHAR(191) NOT NULL,
+	`quantity` INT NOT NULL,
+	PRIMARY KEY(`needId`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_20/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_20/generated/entities/entities_db_script.sql
@@ -3,28 +3,28 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Vehicle;
-DROP TABLE IF EXISTS Employee;
-DROP TABLE IF EXISTS Company;
+DROP TABLE IF EXISTS `Vehicle`;
+DROP TABLE IF EXISTS `Employee`;
+DROP TABLE IF EXISTS `Company`;
 
-CREATE TABLE Company (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	PRIMARY KEY(id)
+CREATE TABLE `Company` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Employee (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	companyId INT NOT NULL,
-	CONSTRAINT FK_EMPLOYEE_COMPANY FOREIGN KEY(companyId) REFERENCES Company(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Employee` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`companyId` INT NOT NULL,
+	CONSTRAINT FK_EMPLOYEE_COMPANY FOREIGN KEY(`companyId`) REFERENCES `Company`(`id`),
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Vehicle (
-	model INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	employeeId INT NOT NULL,
-	CONSTRAINT FK_VEHICLE_EMPLOYEE FOREIGN KEY(employeeId) REFERENCES Employee(id),
-	PRIMARY KEY(model)
+CREATE TABLE `Vehicle` (
+	`model` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`employeeId` INT NOT NULL,
+	CONSTRAINT FK_VEHICLE_EMPLOYEE FOREIGN KEY(`employeeId`) REFERENCES `Employee`(`id`),
+	PRIMARY KEY(`model`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_21/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_21/generated/entities/entities_db_script.sql
@@ -3,23 +3,23 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS MedicalNeed;
-DROP TABLE IF EXISTS AidPackageOrderItem;
+DROP TABLE IF EXISTS `MedicalNeed`;
+DROP TABLE IF EXISTS `AidPackageOrderItem`;
 
-CREATE TABLE AidPackageOrderItem (
-	id INT NOT NULL,
-	quantity INT NOT NULL,
-	totalAmount INT NOT NULL,
-	PRIMARY KEY(id)
+CREATE TABLE `AidPackageOrderItem` (
+	`id` INT NOT NULL,
+	`quantity` INT NOT NULL,
+	`totalAmount` INT NOT NULL,
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE MedicalNeed (
-	needId INT NOT NULL,
-	beneficiaryId INT NOT NULL,
-	period DATETIME NOT NULL,
-	urgency VARCHAR(191) NOT NULL,
-	quantity INT NOT NULL,
-	aidpackageorderitemId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_MEDICALNEED_AIDPACKAGEORDERITEM FOREIGN KEY(aidpackageorderitemId) REFERENCES AidPackageOrderItem(id),
-	PRIMARY KEY(needId)
+CREATE TABLE `MedicalNeed` (
+	`needId` INT NOT NULL,
+	`beneficiaryId` INT NOT NULL,
+	`period` DATETIME NOT NULL,
+	`urgency` VARCHAR(191) NOT NULL,
+	`quantity` INT NOT NULL,
+	`aidpackageorderitemId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_MEDICALNEED_AIDPACKAGEORDERITEM FOREIGN KEY(`aidpackageorderitemId`) REFERENCES `AidPackageOrderItem`(`id`),
+	PRIMARY KEY(`needId`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_24/generated/foo/foo_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_24/generated/foo/foo_db_script.sql
@@ -3,11 +3,11 @@
 -- This file is an auto-generated file by Ballerina persistence layer for foo.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS ByteTest;
+DROP TABLE IF EXISTS `ByteTest`;
 
-CREATE TABLE ByteTest (
-	id INT NOT NULL,
-	binary1 BINARY NOT NULL,
-	binaryOptional BINARY,
-	PRIMARY KEY(id)
+CREATE TABLE `ByteTest` (
+	`id` INT NOT NULL,
+	`binary1` BINARY NOT NULL,
+	`binaryOptional` BINARY,
+	PRIMARY KEY(`id`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_25/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_25/generated/entities/entities_db_script.sql
@@ -3,28 +3,28 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Vehicle;
-DROP TABLE IF EXISTS Employee;
-DROP TABLE IF EXISTS Company;
+DROP TABLE IF EXISTS `Vehicle`;
+DROP TABLE IF EXISTS `Employee`;
+DROP TABLE IF EXISTS `Company`;
 
-CREATE TABLE Company (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	PRIMARY KEY(id)
+CREATE TABLE `Company` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Employee (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	companyId INT NOT NULL,
-	CONSTRAINT FK_EMPLOYEE_COMPANY FOREIGN KEY(companyId) REFERENCES Company(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Employee` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`companyId` INT NOT NULL,
+	CONSTRAINT FK_EMPLOYEE_COMPANY FOREIGN KEY(`companyId`) REFERENCES `Company`(`id`),
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Vehicle (
-	model INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	employeeId INT NOT NULL,
-	CONSTRAINT FK_VEHICLE_EMPLOYEE FOREIGN KEY(employeeId) REFERENCES Employee(id),
-	PRIMARY KEY(model)
+CREATE TABLE `Vehicle` (
+	`model` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`employeeId` INT NOT NULL,
+	CONSTRAINT FK_VEHICLE_EMPLOYEE FOREIGN KEY(`employeeId`) REFERENCES `Employee`(`id`),
+	PRIMARY KEY(`model`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_27/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_27/generated/entities/entities_db_script.sql
@@ -3,30 +3,30 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Profile;
-DROP TABLE IF EXISTS User;
-DROP TABLE IF EXISTS MultipleAssociations;
+DROP TABLE IF EXISTS `Profile`;
+DROP TABLE IF EXISTS `User`;
+DROP TABLE IF EXISTS `MultipleAssociations`;
 
-CREATE TABLE MultipleAssociations (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	PRIMARY KEY(id)
+CREATE TABLE `MultipleAssociations` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE User (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	multipleassociationsId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_USER_MULTIPLEASSOCIATIONS FOREIGN KEY(multipleassociationsId) REFERENCES MultipleAssociations(id),
-	PRIMARY KEY(id)
+CREATE TABLE `User` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`multipleassociationsId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_USER_MULTIPLEASSOCIATIONS FOREIGN KEY(`multipleassociationsId`) REFERENCES `MultipleAssociations`(`id`),
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Profile (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	userId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_PROFILE_USER FOREIGN KEY(userId) REFERENCES User(id),
-	multipleassociationsId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_PROFILE_MULTIPLEASSOCIATIONS FOREIGN KEY(multipleassociationsId) REFERENCES MultipleAssociations(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Profile` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`userId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_PROFILE_USER FOREIGN KEY(`userId`) REFERENCES `User`(`id`),
+	`multipleassociationsId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_PROFILE_MULTIPLEASSOCIATIONS FOREIGN KEY(`multipleassociationsId`) REFERENCES `MultipleAssociations`(`id`),
+	PRIMARY KEY(`id`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_28/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_28/generated/entities/entities_db_script.sql
@@ -3,19 +3,19 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Employee;
-DROP TABLE IF EXISTS Company;
+DROP TABLE IF EXISTS `Employee`;
+DROP TABLE IF EXISTS `Company`;
 
-CREATE TABLE Company (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	PRIMARY KEY(id)
+CREATE TABLE `Company` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Employee (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	companyId INT NOT NULL,
-	CONSTRAINT FK_EMPLOYEE_COMPANY FOREIGN KEY(companyId) REFERENCES Company(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Employee` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`companyId` INT NOT NULL,
+	CONSTRAINT FK_EMPLOYEE_COMPANY FOREIGN KEY(`companyId`) REFERENCES `Company`(`id`),
+	PRIMARY KEY(`id`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_29/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_29/generated/entities/entities_db_script.sql
@@ -3,14 +3,14 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS MedicalNeed;
+DROP TABLE IF EXISTS `MedicalNeed`;
 
-CREATE TABLE MedicalNeed (
-	needId INT NOT NULL,
-	itemId INT NOT NULL,
-	beneficiaryId INT NOT NULL,
-	period DATETIME NOT NULL,
-	urgency VARCHAR(191) NOT NULL,
-	quantity INT NOT NULL,
-	PRIMARY KEY(needId)
+CREATE TABLE `MedicalNeed` (
+	`needId` INT NOT NULL,
+	`itemId` INT NOT NULL,
+	`beneficiaryId` INT NOT NULL,
+	`period` DATETIME NOT NULL,
+	`urgency` VARCHAR(191) NOT NULL,
+	`quantity` INT NOT NULL,
+	PRIMARY KEY(`needId`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_32/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_32/generated/entities/entities_db_script.sql
@@ -3,12 +3,12 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS MedicalItem;
+DROP TABLE IF EXISTS `MedicalItem`;
 
-CREATE TABLE MedicalItem (
-	itemId INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	type VARCHAR(191) NOT NULL,
-	unit VARCHAR(191) NOT NULL,
-	PRIMARY KEY(itemId)
+CREATE TABLE `MedicalItem` (
+	`itemId` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`type` VARCHAR(191) NOT NULL,
+	`unit` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`itemId`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_34/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_34/generated/entities/entities_db_script.sql
@@ -3,19 +3,19 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Profile;
-DROP TABLE IF EXISTS User;
+DROP TABLE IF EXISTS `Profile`;
+DROP TABLE IF EXISTS `User`;
 
-CREATE TABLE User (
-	id INT NOT NULL,
-	PRIMARY KEY(id)
+CREATE TABLE `User` (
+	`id` INT NOT NULL,
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Profile (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	gender VARCHAR(191),
-	userId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_PROFILE_USER FOREIGN KEY(userId) REFERENCES User(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Profile` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`gender` VARCHAR(191),
+	`userId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_PROFILE_USER FOREIGN KEY(`userId`) REFERENCES `User`(`id`),
+	PRIMARY KEY(`id`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_35/generated/persist_generate_35_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_35/generated/persist_generate_35_db_script.sql
@@ -3,44 +3,44 @@
 -- This file is an auto-generated file by Ballerina persistence layer for persist_generate_35.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Workspace;
-DROP TABLE IF EXISTS Employee;
-DROP TABLE IF EXISTS Building;
-DROP TABLE IF EXISTS Department;
+DROP TABLE IF EXISTS `Workspace`;
+DROP TABLE IF EXISTS `Employee`;
+DROP TABLE IF EXISTS `Building`;
+DROP TABLE IF EXISTS `Department`;
 
-CREATE TABLE Department (
-	deptNo VARCHAR(191) NOT NULL,
-	deptName VARCHAR(191) NOT NULL,
-	PRIMARY KEY(deptNo)
+CREATE TABLE `Department` (
+	`deptNo` VARCHAR(191) NOT NULL,
+	`deptName` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`deptNo`)
 );
 
-CREATE TABLE Building (
-	buildingCode VARCHAR(191) NOT NULL,
-	city VARCHAR(191) NOT NULL,
-	state VARCHAR(191) NOT NULL,
-	country VARCHAR(191) NOT NULL,
-	postalCode VARCHAR(191) NOT NULL,
-	PRIMARY KEY(buildingCode)
+CREATE TABLE `Building` (
+	`buildingCode` VARCHAR(191) NOT NULL,
+	`city` VARCHAR(191) NOT NULL,
+	`state` VARCHAR(191) NOT NULL,
+	`country` VARCHAR(191) NOT NULL,
+	`postalCode` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`buildingCode`)
 );
 
-CREATE TABLE Employee (
-	empNo VARCHAR(191) NOT NULL,
-	firstName VARCHAR(191) NOT NULL,
-	lastName VARCHAR(191) NOT NULL,
-	birthDate DATE NOT NULL,
-	gender VARCHAR(191) NOT NULL,
-	hireDate DATE NOT NULL,
-	departmentDeptNo VARCHAR(191) NOT NULL,
-	CONSTRAINT FK_EMPLOYEE_DEPARTMENT FOREIGN KEY(departmentDeptNo) REFERENCES Department(deptNo),
-	PRIMARY KEY(empNo)
+CREATE TABLE `Employee` (
+	`empNo` VARCHAR(191) NOT NULL,
+	`firstName` VARCHAR(191) NOT NULL,
+	`lastName` VARCHAR(191) NOT NULL,
+	`birthDate` DATE NOT NULL,
+	`gender` VARCHAR(191) NOT NULL,
+	`hireDate` DATE NOT NULL,
+	`departmentDeptNo` VARCHAR(191) NOT NULL,
+	CONSTRAINT FK_EMPLOYEE_DEPARTMENT FOREIGN KEY(`departmentDeptNo`) REFERENCES `Department`(`deptNo`),
+	PRIMARY KEY(`empNo`)
 );
 
-CREATE TABLE Workspace (
-	workspaceId VARCHAR(191) NOT NULL,
-	workspaceType VARCHAR(191) NOT NULL,
-	buildingBuildingCode VARCHAR(191) NOT NULL,
-	CONSTRAINT FK_WORKSPACE_BUILDING FOREIGN KEY(buildingBuildingCode) REFERENCES Building(buildingCode),
-	employeeEmpNo VARCHAR(191) UNIQUE NOT NULL,
-	CONSTRAINT FK_WORKSPACE_EMPLOYEE FOREIGN KEY(employeeEmpNo) REFERENCES Employee(empNo),
-	PRIMARY KEY(workspaceId)
+CREATE TABLE `Workspace` (
+	`workspaceId` VARCHAR(191) NOT NULL,
+	`workspaceType` VARCHAR(191) NOT NULL,
+	`buildingBuildingCode` VARCHAR(191) NOT NULL,
+	CONSTRAINT FK_WORKSPACE_BUILDING FOREIGN KEY(`buildingBuildingCode`) REFERENCES `Building`(`buildingCode`),
+	`employeeEmpNo` VARCHAR(191) UNIQUE NOT NULL,
+	CONSTRAINT FK_WORKSPACE_EMPLOYEE FOREIGN KEY(`employeeEmpNo`) REFERENCES `Employee`(`empNo`),
+	PRIMARY KEY(`workspaceId`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_36/generated/rainier/rainier_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_36/generated/rainier/rainier_db_script.sql
@@ -3,54 +3,54 @@
 -- This file is an auto-generated file by Ballerina persistence layer for rainier.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Employee;
-DROP TABLE IF EXISTS Workspace;
-DROP TABLE IF EXISTS Building;
-DROP TABLE IF EXISTS Department;
-DROP TABLE IF EXISTS OrderItem;
+DROP TABLE IF EXISTS `Employee`;
+DROP TABLE IF EXISTS `Workspace`;
+DROP TABLE IF EXISTS `Building`;
+DROP TABLE IF EXISTS `Department`;
+DROP TABLE IF EXISTS `OrderItem`;
 
-CREATE TABLE OrderItem (
-	orderId VARCHAR(191) NOT NULL,
-	itemId VARCHAR(191) NOT NULL,
-	quantity INT NOT NULL,
-	notes VARCHAR(191) NOT NULL,
-	PRIMARY KEY(orderId,itemId)
+CREATE TABLE `OrderItem` (
+	`orderId` VARCHAR(191) NOT NULL,
+	`itemId` VARCHAR(191) NOT NULL,
+	`quantity` INT NOT NULL,
+	`notes` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`orderId`,`itemId`)
 );
 
-CREATE TABLE Department (
-	deptNo VARCHAR(191) NOT NULL,
-	deptName VARCHAR(191) NOT NULL,
-	PRIMARY KEY(deptNo)
+CREATE TABLE `Department` (
+	`deptNo` VARCHAR(191) NOT NULL,
+	`deptName` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`deptNo`)
 );
 
-CREATE TABLE Building (
-	buildingCode VARCHAR(191) NOT NULL,
-	city VARCHAR(191) NOT NULL,
-	state VARCHAR(191) NOT NULL,
-	country VARCHAR(191) NOT NULL,
-	postalCode VARCHAR(191) NOT NULL,
-	type VARCHAR(191) NOT NULL,
-	PRIMARY KEY(buildingCode)
+CREATE TABLE `Building` (
+	`buildingCode` VARCHAR(191) NOT NULL,
+	`city` VARCHAR(191) NOT NULL,
+	`state` VARCHAR(191) NOT NULL,
+	`country` VARCHAR(191) NOT NULL,
+	`postalCode` VARCHAR(191) NOT NULL,
+	`type` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`buildingCode`)
 );
 
-CREATE TABLE Workspace (
-	workspaceId VARCHAR(191) NOT NULL,
-	workspaceType VARCHAR(191) NOT NULL,
-	buildingBuildingCode VARCHAR(191) NOT NULL,
-	CONSTRAINT FK_WORKSPACE_BUILDING FOREIGN KEY(buildingBuildingCode) REFERENCES Building(buildingCode),
-	PRIMARY KEY(workspaceId)
+CREATE TABLE `Workspace` (
+	`workspaceId` VARCHAR(191) NOT NULL,
+	`workspaceType` VARCHAR(191) NOT NULL,
+	`buildingBuildingCode` VARCHAR(191) NOT NULL,
+	CONSTRAINT FK_WORKSPACE_BUILDING FOREIGN KEY(`buildingBuildingCode`) REFERENCES `Building`(`buildingCode`),
+	PRIMARY KEY(`workspaceId`)
 );
 
-CREATE TABLE Employee (
-	empNo VARCHAR(191) NOT NULL,
-	firstName VARCHAR(191) NOT NULL,
-	lastName VARCHAR(191) NOT NULL,
-	birthDate DATE NOT NULL,
-	gender VARCHAR(191) NOT NULL,
-	hireDate DATE NOT NULL,
-	departmentDeptNo VARCHAR(191) NOT NULL,
-	CONSTRAINT FK_EMPLOYEE_DEPARTMENT FOREIGN KEY(departmentDeptNo) REFERENCES Department(deptNo),
-	workspaceWorkspaceId VARCHAR(191) UNIQUE NOT NULL,
-	CONSTRAINT FK_EMPLOYEE_WORKSPACE FOREIGN KEY(workspaceWorkspaceId) REFERENCES Workspace(workspaceId),
-	PRIMARY KEY(empNo)
+CREATE TABLE `Employee` (
+	`empNo` VARCHAR(191) NOT NULL,
+	`firstName` VARCHAR(191) NOT NULL,
+	`lastName` VARCHAR(191) NOT NULL,
+	`birthDate` DATE NOT NULL,
+	`gender` VARCHAR(191) NOT NULL,
+	`hireDate` DATE NOT NULL,
+	`departmentDeptNo` VARCHAR(191) NOT NULL,
+	CONSTRAINT FK_EMPLOYEE_DEPARTMENT FOREIGN KEY(`departmentDeptNo`) REFERENCES `Department`(`deptNo`),
+	`workspaceWorkspaceId` VARCHAR(191) UNIQUE NOT NULL,
+	CONSTRAINT FK_EMPLOYEE_WORKSPACE FOREIGN KEY(`workspaceWorkspaceId`) REFERENCES `Workspace`(`workspaceId`),
+	PRIMARY KEY(`empNo`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_37/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_37/generated/entities/entities_db_script.sql
@@ -3,61 +3,61 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Profile;
-DROP TABLE IF EXISTS User;
-DROP TABLE IF EXISTS Dept;
-DROP TABLE IF EXISTS Customer;
-DROP TABLE IF EXISTS MultipleAssociations;
-DROP TABLE IF EXISTS Student;
+DROP TABLE IF EXISTS `Profile`;
+DROP TABLE IF EXISTS `User`;
+DROP TABLE IF EXISTS `Dept`;
+DROP TABLE IF EXISTS `Customer`;
+DROP TABLE IF EXISTS `MultipleAssociations`;
+DROP TABLE IF EXISTS `Student`;
 
-CREATE TABLE Student (
-	id INT NOT NULL,
-	firstName VARCHAR(191) NOT NULL,
-	age INT NOT NULL,
-	lastName VARCHAR(191) NOT NULL,
-	nicNo VARCHAR(191) NOT NULL,
-	PRIMARY KEY(id,firstName)
+CREATE TABLE `Student` (
+	`id` INT NOT NULL,
+	`firstName` VARCHAR(191) NOT NULL,
+	`age` INT NOT NULL,
+	`lastName` VARCHAR(191) NOT NULL,
+	`nicNo` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`id`,`firstName`)
 );
 
-CREATE TABLE MultipleAssociations (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	PRIMARY KEY(id)
+CREATE TABLE `MultipleAssociations` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Customer (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	age INT NOT NULL,
-	multipleassociationsId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_CUSTOMER_MULTIPLEASSOCIATIONS FOREIGN KEY(multipleassociationsId) REFERENCES MultipleAssociations(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Customer` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`age` INT NOT NULL,
+	`multipleassociationsId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_CUSTOMER_MULTIPLEASSOCIATIONS FOREIGN KEY(`multipleassociationsId`) REFERENCES `MultipleAssociations`(`id`),
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Dept (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	multipleassociationsId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_DEPT_MULTIPLEASSOCIATIONS FOREIGN KEY(multipleassociationsId) REFERENCES MultipleAssociations(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Dept` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`multipleassociationsId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_DEPT_MULTIPLEASSOCIATIONS FOREIGN KEY(`multipleassociationsId`) REFERENCES `MultipleAssociations`(`id`),
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE User (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	multipleassociationsId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_USER_MULTIPLEASSOCIATIONS FOREIGN KEY(multipleassociationsId) REFERENCES MultipleAssociations(id),
-	PRIMARY KEY(id)
+CREATE TABLE `User` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`multipleassociationsId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_USER_MULTIPLEASSOCIATIONS FOREIGN KEY(`multipleassociationsId`) REFERENCES `MultipleAssociations`(`id`),
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Profile (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	isAdult BOOLEAN NOT NULL,
-	salary DOUBLE NOT NULL,
-	age DECIMAL(65,30) NOT NULL,
-	isRegistered BINARY NOT NULL,
-	userId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_PROFILE_USER FOREIGN KEY(userId) REFERENCES User(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Profile` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`isAdult` BOOLEAN NOT NULL,
+	`salary` DOUBLE NOT NULL,
+	`age` DECIMAL(65,30) NOT NULL,
+	`isRegistered` BINARY NOT NULL,
+	`userId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_PROFILE_USER FOREIGN KEY(`userId`) REFERENCES `User`(`id`),
+	PRIMARY KEY(`id`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_39/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_39/generated/entities/entities_db_script.sql
@@ -3,19 +3,19 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Employee;
-DROP TABLE IF EXISTS Company;
+DROP TABLE IF EXISTS `Employee`;
+DROP TABLE IF EXISTS `Company`;
 
-CREATE TABLE Company (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	PRIMARY KEY(id)
+CREATE TABLE `Company` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Employee (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	companyId INT NOT NULL,
-	CONSTRAINT FK_EMPLOYEE_COMPANY FOREIGN KEY(companyId) REFERENCES Company(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Employee` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`companyId` INT NOT NULL,
+	CONSTRAINT FK_EMPLOYEE_COMPANY FOREIGN KEY(`companyId`) REFERENCES `Company`(`id`),
+	PRIMARY KEY(`id`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_40/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_40/generated/entities/entities_db_script.sql
@@ -3,19 +3,19 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Profile;
-DROP TABLE IF EXISTS User;
+DROP TABLE IF EXISTS `Profile`;
+DROP TABLE IF EXISTS `User`;
 
-CREATE TABLE User (
-	id INT NOT NULL,
-	PRIMARY KEY(id)
+CREATE TABLE `User` (
+	`id` INT NOT NULL,
+	PRIMARY KEY(`id`)
 );
 
-CREATE TABLE Profile (
-	id INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	gender VARCHAR(191),
-	userId INT UNIQUE NOT NULL,
-	CONSTRAINT FK_PROFILE_USER FOREIGN KEY(userId) REFERENCES User(id),
-	PRIMARY KEY(id)
+CREATE TABLE `Profile` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`gender` VARCHAR(191),
+	`userId` INT UNIQUE NOT NULL,
+	CONSTRAINT FK_PROFILE_USER FOREIGN KEY(`userId`) REFERENCES `User`(`id`),
+	PRIMARY KEY(`id`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_41/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_41/generated/entities/entities_db_script.sql
@@ -3,57 +3,57 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS Workspace;
-DROP TABLE IF EXISTS Employee;
-DROP TABLE IF EXISTS Building;
-DROP TABLE IF EXISTS Department;
-DROP TABLE IF EXISTS OrderItem;
+DROP TABLE IF EXISTS `Workspace`;
+DROP TABLE IF EXISTS `Employee`;
+DROP TABLE IF EXISTS `Building`;
+DROP TABLE IF EXISTS `Department`;
+DROP TABLE IF EXISTS `OrderItem`;
 
-CREATE TABLE OrderItem (
-	orderId VARCHAR(191) NOT NULL,
-	itemId VARCHAR(191) NOT NULL,
-	quantity INT NOT NULL,
-	notes VARCHAR(191) NOT NULL,
-	PRIMARY KEY(orderId,itemId)
+CREATE TABLE `OrderItem` (
+	`orderId` VARCHAR(191) NOT NULL,
+	`itemId` VARCHAR(191) NOT NULL,
+	`quantity` INT NOT NULL,
+	`notes` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`orderId`,`itemId`)
 );
 
-CREATE TABLE Department (
-	deptNo VARCHAR(191) NOT NULL,
-	deptName VARCHAR(191) NOT NULL,
-	PRIMARY KEY(deptNo)
+CREATE TABLE `Department` (
+	`deptNo` VARCHAR(191) NOT NULL,
+	`deptName` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`deptNo`)
 );
 
-CREATE TABLE Building (
-	buildingCode VARCHAR(191) NOT NULL,
-	city VARCHAR(191) NOT NULL,
-	state VARCHAR(191) NOT NULL,
-	country VARCHAR(191) NOT NULL,
-	postalCode VARCHAR(191) NOT NULL,
-	PRIMARY KEY(buildingCode)
+CREATE TABLE `Building` (
+	`buildingCode` VARCHAR(191) NOT NULL,
+	`city` VARCHAR(191) NOT NULL,
+	`state` VARCHAR(191) NOT NULL,
+	`country` VARCHAR(191) NOT NULL,
+	`postalCode` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`buildingCode`)
 );
 
-CREATE TABLE Employee (
-	empNo VARCHAR(191) NOT NULL,
-	firstName VARCHAR(191) NOT NULL,
-	lastName VARCHAR(191) NOT NULL,
-	birthDate DATE NOT NULL,
-	gender VARCHAR(191) NOT NULL,
-	hireDate DATE NOT NULL,
-	departmentDeptNo VARCHAR(191) NOT NULL,
-	CONSTRAINT FK_EMPLOYEE_DEPARTMENT FOREIGN KEY(departmentDeptNo) REFERENCES Department(deptNo),
-	orderitemOrderId VARCHAR(191) NOT NULL,
-	orderitemItemId VARCHAR(191) NOT NULL,
-	UNIQUE (orderitemOrderId, orderitemItemId),
-	CONSTRAINT FK_EMPLOYEE_ORDERITEM FOREIGN KEY(orderitemOrderId, orderitemItemId) REFERENCES OrderItem(orderId, itemId),
-	PRIMARY KEY(empNo)
+CREATE TABLE `Employee` (
+	`empNo` VARCHAR(191) NOT NULL,
+	`firstName` VARCHAR(191) NOT NULL,
+	`lastName` VARCHAR(191) NOT NULL,
+	`birthDate` DATE NOT NULL,
+	`gender` VARCHAR(191) NOT NULL,
+	`hireDate` DATE NOT NULL,
+	`departmentDeptNo` VARCHAR(191) NOT NULL,
+	CONSTRAINT FK_EMPLOYEE_DEPARTMENT FOREIGN KEY(`departmentDeptNo`) REFERENCES `Department`(`deptNo`),
+	`orderitemOrderId` VARCHAR(191) NOT NULL,
+	`orderitemItemId` VARCHAR(191) NOT NULL,
+	UNIQUE (`orderitemOrderId`, `orderitemItemId`),
+	CONSTRAINT FK_EMPLOYEE_ORDERITEM FOREIGN KEY(`orderitemOrderId`, `orderitemItemId`) REFERENCES `OrderItem`(`orderId`, `itemId`),
+	PRIMARY KEY(`empNo`)
 );
 
-CREATE TABLE Workspace (
-	workspaceId VARCHAR(191) NOT NULL,
-	workspaceType VARCHAR(191) NOT NULL,
-	buildingBuildingCode VARCHAR(191) NOT NULL,
-	CONSTRAINT FK_WORKSPACE_BUILDING FOREIGN KEY(buildingBuildingCode) REFERENCES Building(buildingCode),
-	employeeEmpNo VARCHAR(191) UNIQUE NOT NULL,
-	CONSTRAINT FK_WORKSPACE_EMPLOYEE FOREIGN KEY(employeeEmpNo) REFERENCES Employee(empNo),
-	PRIMARY KEY(workspaceId)
+CREATE TABLE `Workspace` (
+	`workspaceId` VARCHAR(191) NOT NULL,
+	`workspaceType` VARCHAR(191) NOT NULL,
+	`buildingBuildingCode` VARCHAR(191) NOT NULL,
+	CONSTRAINT FK_WORKSPACE_BUILDING FOREIGN KEY(`buildingBuildingCode`) REFERENCES `Building`(`buildingCode`),
+	`employeeEmpNo` VARCHAR(191) UNIQUE NOT NULL,
+	CONSTRAINT FK_WORKSPACE_EMPLOYEE FOREIGN KEY(`employeeEmpNo`) REFERENCES `Employee`(`empNo`),
+	PRIMARY KEY(`workspaceId`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_5/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_5/generated/entities/entities_db_script.sql
@@ -3,24 +3,24 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS MedicalNeed;
-DROP TABLE IF EXISTS MedicalItem;
+DROP TABLE IF EXISTS `MedicalNeed`;
+DROP TABLE IF EXISTS `MedicalItem`;
 
-CREATE TABLE MedicalItem (
-	itemId INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	type VARCHAR(191) NOT NULL,
-	unit INT NOT NULL,
-	PRIMARY KEY(itemId)
+CREATE TABLE `MedicalItem` (
+	`itemId` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`type` VARCHAR(191) NOT NULL,
+	`unit` INT NOT NULL,
+	PRIMARY KEY(`itemId`)
 );
 
-CREATE TABLE MedicalNeed (
-	needId INT NOT NULL,
-	itemId INT NOT NULL,
-	name VARCHAR(191) NOT NULL,
-	beneficiaryId INT NOT NULL,
-	period DATETIME NOT NULL,
-	urgency VARCHAR(191) NOT NULL,
-	quantity VARCHAR(191) NOT NULL,
-	PRIMARY KEY(needId)
+CREATE TABLE `MedicalNeed` (
+	`needId` INT NOT NULL,
+	`itemId` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`beneficiaryId` INT NOT NULL,
+	`period` DATETIME NOT NULL,
+	`urgency` VARCHAR(191) NOT NULL,
+	`quantity` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`needId`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_6/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_6/generated/entities/entities_db_script.sql
@@ -3,18 +3,18 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS DataType;
+DROP TABLE IF EXISTS `DataType`;
 
-CREATE TABLE DataType (
-	a INT NOT NULL,
-	b1 VARCHAR(191) NOT NULL,
-	c1 INT NOT NULL,
-	d1 BOOLEAN NOT NULL,
-	e1 DOUBLE NOT NULL,
-	f1 DECIMAL(65,30) NOT NULL,
-	j1 TIMESTAMP NOT NULL,
-	k1 DATETIME NOT NULL,
-	l1 DATE NOT NULL,
-	m1 TIME NOT NULL,
-	PRIMARY KEY(a)
+CREATE TABLE `DataType` (
+	`a` INT NOT NULL,
+	`b1` VARCHAR(191) NOT NULL,
+	`c1` INT NOT NULL,
+	`d1` BOOLEAN NOT NULL,
+	`e1` DOUBLE NOT NULL,
+	`f1` DECIMAL(65,30) NOT NULL,
+	`j1` TIMESTAMP NOT NULL,
+	`k1` DATETIME NOT NULL,
+	`l1` DATE NOT NULL,
+	`m1` TIME NOT NULL,
+	PRIMARY KEY(`a`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_8/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_8/generated/entities/entities_db_script.sql
@@ -3,14 +3,14 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS MedicalNeed;
+DROP TABLE IF EXISTS `MedicalNeed`;
 
-CREATE TABLE MedicalNeed (
-	needId VARCHAR(191) NOT NULL,
-	itemId INT NOT NULL,
-	beneficiaryId INT NOT NULL,
-	period DATETIME NOT NULL,
-	urgency VARCHAR(191) NOT NULL,
-	quantity INT NOT NULL,
-	PRIMARY KEY(needId)
+CREATE TABLE `MedicalNeed` (
+	`needId` VARCHAR(191) NOT NULL,
+	`itemId` INT NOT NULL,
+	`beneficiaryId` INT NOT NULL,
+	`period` DATETIME NOT NULL,
+	`urgency` VARCHAR(191) NOT NULL,
+	`quantity` INT NOT NULL,
+	PRIMARY KEY(`needId`)
 );

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_9/generated/entities/entities_db_script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_9/generated/entities/entities_db_script.sql
@@ -3,14 +3,14 @@
 -- This file is an auto-generated file by Ballerina persistence layer for entities.
 -- Please verify the generated scripts and execute them against the target DB server.
 
-DROP TABLE IF EXISTS MedicalNeed;
+DROP TABLE IF EXISTS `MedicalNeed`;
 
-CREATE TABLE MedicalNeed (
-	needId INT NOT NULL,
-	itemId INT NOT NULL,
-	beneficiaryId INT NOT NULL,
-	period DATETIME NOT NULL,
-	urgency VARCHAR(191) NOT NULL,
-	quantity INT NOT NULL,
-	PRIMARY KEY(needId,itemId)
+CREATE TABLE `MedicalNeed` (
+	`needId` INT NOT NULL,
+	`itemId` INT NOT NULL,
+	`beneficiaryId` INT NOT NULL,
+	`period` DATETIME NOT NULL,
+	`urgency` VARCHAR(191) NOT NULL,
+	`quantity` INT NOT NULL,
+	PRIMARY KEY(`needId`,`itemId`)
 );


### PR DESCRIPTION
## Purpose
$Subject

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/4175

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
