### PR TITLE
Update persist init command help text

### DIFF
--- a/persist-cli/src/main/resources/cli-help/ballerina-persist-init.help
+++ b/persist-cli/src/main/resources/cli-help/ballerina-persist-init.help
@@ -15,7 +15,8 @@ OPTIONS
        --module <module name>
               The name of the module to initialize the persistence layer. If not specified, the default module will be used.
        --datastore <store type>
-              The type of the datastore to be used for persistence. Only 'mysql' is supported at the moment.
+              The type of the datastore to be used for persistence.
+              The supported datastores are 'inmemory', 'mysql', 'mssql', and 'googlesheets'.
        -h, --help
            Print the usage details of all commands.
 

--- a/persist-cli/src/main/resources/cli-help/ballerina-persist-init.help
+++ b/persist-cli/src/main/resources/cli-help/ballerina-persist-init.help
@@ -17,6 +17,7 @@ OPTIONS
        --datastore <store type>
               The type of the datastore to be used for persistence.
               The supported datastores are 'inmemory', 'mysql', 'mssql', and 'googlesheets'.
+              If not specified, the 'inmemory' datastore will be used as the default.
        -h, --help
            Print the usage details of all commands.
 


### PR DESCRIPTION
## Purpose
$subject

This PR adds "mssql", "inmemory" and "googlesheets" to the supported datastore types in the help text