### PR TITLE
Improve annotation support for MSSQL and PostgreSQL databases

### DIFF
--- a/examples/hospital/persist/model.bal
+++ b/examples/hospital/persist/model.bal
@@ -49,7 +49,7 @@ public type Appointment record {|
 
 @sql:Name {value: "patients"}
 public type Patient record {|
-    @sql:Name {value: "ID"}
+    @sql:Name {value: "IDP"}
     @sql:Generated
     readonly int id;
     string name;

--- a/examples/hospital/tests/demo_test.bal
+++ b/examples/hospital/tests/demo_test.bal
@@ -42,13 +42,13 @@ function initDatabase() returns error? {
 	        PRIMARY KEY(id)
       )`);
     _ = check dbClient->execute(`CREATE TABLE patients (
-          ID INT AUTO_INCREMENT,
+          IDP INT AUTO_INCREMENT,
           name VARCHAR(191) NOT NULL,
           age INT NOT NULL,
           ADDRESS VARCHAR(191) NOT NULL,
           phoneNumber CHAR(10) NOT NULL,
           gender ENUM('MALE', 'FEMALE') NOT NULL,
-          PRIMARY KEY(ID)
+          PRIMARY KEY(IDP)
       )`);
     _ = check dbClient->execute(`CREATE TABLE appointment (
           id INT NOT NULL,
@@ -56,7 +56,7 @@ function initDatabase() returns error? {
           appointmentTime DATETIME NOT NULL,
           status ENUM('SCHEDULED', 'STARTED', 'ENDED') NOT NULL,
           patient_id INT NOT NULL,
-          FOREIGN KEY(patient_id) REFERENCES patients(ID),
+          FOREIGN KEY(patient_id) REFERENCES patients(IDP),
           doctorId INT NOT NULL,
           FOREIGN KEY(doctorId) REFERENCES Doctor(id),
           PRIMARY KEY(id)

--- a/examples/hospital_unsupported/persist/model.bal
+++ b/examples/hospital_unsupported/persist/model.bal
@@ -64,6 +64,7 @@ public type Patient record {|
 
 public type Doctor record {|
     readonly int id;
+    @sql:Name {value: "doctor_name"}
     string name;
     @sql:Index {name: ["specialty_index"]}
     string specialty;

--- a/examples/hospital_unsupported/tests/demo_test.bal
+++ b/examples/hospital_unsupported/tests/demo_test.bal
@@ -35,7 +35,7 @@ function initDatabase() returns error? {
     _ = check dbClient->execute(`USE hospital`);
     _ = check dbClient->execute(`CREATE TABLE Doctor (
 	        id INT NOT NULL,
-	        name VARCHAR(191) NOT NULL,
+	        doctor_name VARCHAR(191) NOT NULL,
 	        specialty VARCHAR(191) NOT NULL,
 	        phone_number VARCHAR(191) NOT NULL,
 	        salary DECIMAL(10,2),

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,7 @@ stdlibSqlVersion=1.11.1
 stdlibPersistVersion=1.3.0-20240314-140700-7048f30
 
 # Level 10
-stdlibPersistSqlVersion=1.3.0-20240314-165400-4b8c6cc
+stdlibPersistSqlVersion=1.3.0-20240320-162400-4d37e2f
 stdlibPersistInmemoryVersion=1.2.0
 stdlibPersistGoogleSheetVersion=1.2.0
 stdlibPersistRedisVersion=0.1.0-20240313-155900-0f5ff0b

--- a/persist-cli-tests/src/test/java/io/ballerina/persist/tools/ToolingGenerateTest.java
+++ b/persist-cli-tests/src/test/java/io/ballerina/persist/tools/ToolingGenerateTest.java
@@ -518,163 +518,232 @@ public class ToolingGenerateTest {
     @Test
     @Description("The model has a relation with relation annotation")
     public void testGenerateEntitiesWithRelationAnnotations() {
-        executeGenerateCommand("tool_test_generate_72", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_72");
+        String subDir = "tool_test_generate_72";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has Mapping annotations on entities")
     public void testGenerateEntitiesWithMappingAnnotations() {
-        executeGenerateCommand("tool_test_generate_73", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_73");
+        String subDir = "tool_test_generate_73";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has Mapping annotations on foreign keys.")
     public void testGenerateEntitiesWithMappingAnnotationOnForeignKeys() {
-        executeGenerateCommand("tool_test_generate_74", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_74");
+        String subDir = "tool_test_generate_74";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has type mapping annotations Char, VarChar and Decimal")
     public void testGenerateEntitiesWithTypeMappingAnnotations() {
-        executeGenerateCommand("tool_test_generate_75", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_75");
+        String subDir = "tool_test_generate_75";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has a unique index on a field")
     public void testGenerateEntitiesWithUniqueIndexesOnOneField() {
-        executeGenerateCommand("tool_test_generate_76", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_76");
+        String subDir = "tool_test_generate_76";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has a single unique index on two fields")
     public void testGenerateEntitiesSameUniqueIndexOnTwoFields() {
-        executeGenerateCommand("tool_test_generate_77", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_77");
+        String subDir = "tool_test_generate_77";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has a single Index on two fields")
     public void testGenerateEntitiesSameIndexOnTwoFields() {
-        executeGenerateCommand("tool_test_generate_78", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_78");
+        String subDir = "tool_test_generate_78";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has an entity whose id field is renamed")
     public void testGenerateEntitiesWithRenamedIdField() {
-        executeGenerateCommand("tool_test_generate_79", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_79");
+        String subDir = "tool_test_generate_79";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has a renamed Id field and a renamed foreign key")
     public void testGenerateEntitiesWithRenamedIdFieldAndForeignKey() {
-        executeGenerateCommand("tool_test_generate_80", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_80");
+        String subDir = "tool_test_generate_80";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has a relation with a composite foreign key")
     public void testGenerateEntitiesCompositeForeignKey() {
-        executeGenerateCommand("tool_test_generate_81", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_81");
+        String subDir = "tool_test_generate_81";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has a relation with a composite foreign key with one key renamed")
     public void testGenerateEntitiesRenamedCompositeForeignKeyPartial() {
-        executeGenerateCommand("tool_test_generate_82", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_82");
+        String subDir = "tool_test_generate_82";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has a relation with a composite foreign key with both keys renamed")
     public void testGenerateEntitiesRenamedCompositeForeignKey() {
-        executeGenerateCommand("tool_test_generate_83", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_83");
+        String subDir = "tool_test_generate_83";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has a relation with a composite foreign key with both keys renamed along with part " +
             "of primary key")
     public void testGenerateEntitiesCompositeForeignKeyWithRenamedKeysPartial() {
-        executeGenerateCommand("tool_test_generate_84", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_84");
+        String subDir = "tool_test_generate_84";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has a relation with a composite foreign key with both keys renamed along with primary keys")
     public void testGenerateEntitiesCompositeForeignKeyWithRenamedKeys() {
-        executeGenerateCommand("tool_test_generate_85", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_85");
+        String subDir = "tool_test_generate_85";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has an Entity with auto generated index on a field")
     public void testGenerateEntitiesWithAutoGeneratedIndex() {
-        executeGenerateCommand("tool_test_generate_86", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_86");
+        String subDir = "tool_test_generate_86";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
-    @Description("The model has an Entity with auto generated index on a field")
+    @Description("The model has an Entity with auto generated unique index on a field")
     public void testGenerateEntitiesWithAutoGeneratedUniqueIndex() {
-        executeGenerateCommand("tool_test_generate_87", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_87");
+        String subDir = "tool_test_generate_87";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has Entities with both index types on same field")
     public void testGenerateEntitiesWithBothIndexTypesOnSameField() {
-        executeGenerateCommand("tool_test_generate_88", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_88");
+        String subDir = "tool_test_generate_88";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has Entities with both index types on same field and one with a name")
     public void testGenerateEntitiesWithBothIndexTypesAndOneWithAName() {
-        executeGenerateCommand("tool_test_generate_89", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_89");
+        String subDir = "tool_test_generate_89";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has Entity with auto generated ID field")
     public void testGenerateEntityWithAutoGeneratedId() {
-        executeGenerateCommand("tool_test_generate_90", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_90");
+        String subDir = "tool_test_generate_90";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has Entity with auto generated ID field with a relation")
     public void testGenerateEntityWithAutoGeneratedIdWithRelation() {
-        executeGenerateCommand("tool_test_generate_91", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_91");
+        String subDir = "tool_test_generate_91";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has Entity with auto generated ID field with a renamed relation")
     public void testGenerateEntityWithAutoGeneratedIdWithRenamedRelation() {
-        executeGenerateCommand("tool_test_generate_92", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_92");
+        String subDir = "tool_test_generate_92";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has multiple relations with relation annotations")
     public void testGenerateEntitiesWithMultipleRelationsOnSame() {
-        executeGenerateCommand("tool_test_generate_93", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_93");
+        String subDir = "tool_test_generate_93";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
     @Description("The model has multiple relations with relation annotations and renamed foreign keys")
     public void testGenerateEntitiesWithMultipleRenamedRelationsOnSame() {
-        executeGenerateCommand("tool_test_generate_94", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_94");
+        String subDir = "tool_test_generate_94";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)
@@ -722,8 +791,11 @@ public class ToolingGenerateTest {
     @Test(enabled = true)
     @Description("The model has entities with unsupported fields")
     public void testGenerateEntitiesWithUnsupportedFields() {
-        executeGenerateCommand("tool_test_generate_101", "mysql", "entities");
-        assertGeneratedSources("tool_test_generate_101");
+        String subDir = "tool_test_generate_101";
+        executeGenerateCommand(subDir, "mysql", "entities");
+        executeGenerateCommand(subDir, "mssql", "mssql_entities");
+        executeGenerateCommand(subDir, "postgresql", "postgresql_entities");
+        assertGeneratedSources(subDir);
     }
 
     @Test(enabled = true)

--- a/persist-cli-tests/src/test/java/io/ballerina/persist/tools/ToolingMigrateTest.java
+++ b/persist-cli-tests/src/test/java/io/ballerina/persist/tools/ToolingMigrateTest.java
@@ -126,6 +126,15 @@ public class ToolingMigrateTest {
         assertGeneratedSources("tool_test_migrate_11");
     }
 
+    @Test(enabled = true)
+    @Description("Test execute command with SQL type annotations")
+    public void testTypeAnnotationsMigrateTest() {
+
+        executeCommand("tool_test_migrate_12");
+        assertGeneratedSources("tool_test_migrate_12");
+    }
+
+
     private void executeCommand(String subDir) {
         Class<?> persistClass;
         Path sourcePath = Paths.get(GENERATED_SOURCES_DIRECTORY, subDir);

--- a/persist-cli-tests/src/test/java/io/ballerina/persist/tools/ToolingMigrateTest.java
+++ b/persist-cli-tests/src/test/java/io/ballerina/persist/tools/ToolingMigrateTest.java
@@ -127,7 +127,7 @@ public class ToolingMigrateTest {
     }
 
     @Test(enabled = true)
-    @Description("Test execute command with SQL type annotations")
+    @Description("Test execute command with SQL type annotations in newly inserted fields")
     public void testTypeAnnotationsMigrateTest() {
 
         executeCommand("tool_test_migrate_12");

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/Ballerina.toml
@@ -1,0 +1,20 @@
+[package]
+org = "wso2"
+name = "persistTest7"
+version = "0.1.0"
+distribution = "2201.5.0"
+
+[build-options]
+observabilityIncluded = true
+
+[[tool.persist]]
+id = "persist"
+options.datastore = "mysql"
+targetModule = "persistTest7"
+filePath = "persist/model.bal"
+
+[[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "persist-native"
+version = "0.3.0"
+

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/main.bal
@@ -1,0 +1,5 @@
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/main.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/io;
 
 public function main() {

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/persist/migrations/20230516081311_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/persist/migrations/20230516081311_firstMigration/model.bal
@@ -1,0 +1,23 @@
+import ballerina/persist as _;
+import ballerina/time;
+
+public type MedicalNeed record {|
+    readonly int id;
+
+    int needId;
+    string itemId;
+    string name;
+    time:Civil period;
+    MedicalItem[] items;
+|};
+
+public type MedicalItem record {|
+    readonly string name;
+
+    int itemId;
+    string decrip;
+    string unit;
+    int num;
+    MedicalNeed need;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/persist/migrations/20230516081311_firstMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/persist/migrations/20230516081311_firstMigration/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS `MedicalItem`;
+DROP TABLE IF EXISTS `MedicalNeed`;
+
+CREATE TABLE `MedicalNeed` (
+	`id` INT NOT NULL,
+	`needId` INT NOT NULL,
+	`itemId` VARCHAR(191) NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`period` DATETIME NOT NULL,
+	PRIMARY KEY(`id`)
+);
+
+CREATE TABLE `MedicalItem` (
+	`name` VARCHAR(191) NOT NULL,
+	`itemId` INT NOT NULL,
+	`decrip` VARCHAR(191) NOT NULL,
+	`unit` VARCHAR(191) NOT NULL,
+	`num` INT NOT NULL,
+	`needId` INT NOT NULL,
+	CONSTRAINT FK_NEED FOREIGN KEY(`needId`) REFERENCES `MedicalNeed`(`id`),
+	PRIMARY KEY(`name`)
+);
+

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/persist/model.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/persist as _;
 import ballerinax/persist.sql;
 import ballerina/time;

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_12/persist/model.bal
@@ -1,0 +1,27 @@
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+import ballerina/time;
+
+public type MedicalNeed record {|
+    readonly int id;
+    @sql:Char {length: 50}
+    string needDetails;
+    @sql:Varchar {length: 50}
+    string needType;
+    @sql:Decimal {precision: [10,2]}
+    decimal amount;
+    int needId;
+    string itemId;
+    string name;
+    time:Civil period;
+    MedicalItem[] items;
+|};
+
+public type MedicalItem record {|
+    readonly string name;
+    int itemId;
+    string decrip;
+    string unit;
+    int num;
+    MedicalNeed need;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/Config.toml
@@ -5,4 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_95.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_95.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,103 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                make: {columnName: "make"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "owner.id": {relation: {entityName: "owner", refField: "id"}},
+                "owner.name": {relation: {entityName: "owner", refField: "name"}},
+                "owner.nic": {relation: {entityName: "owner", refField: "nic"}},
+                "owner.salary": {relation: {entityName: "owner", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {owner: {entity: User, fieldName: "owner", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {[CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)};
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,64 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public type User record {|
+    readonly int id;
+    string name;
+    string nic;
+    decimal salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    string nic?;
+    decimal salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] car?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    string nic?;
+    decimal salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string make;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string make?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized owner?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string make?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/mssql_entities/script.sql
@@ -1,0 +1,17 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[make] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,103 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                make: {columnName: "make"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "owner.id": {relation: {entityName: "owner", refField: "id"}},
+                "owner.name": {relation: {entityName: "owner", refField: "name"}},
+                "owner.nic": {relation: {entityName: "owner", refField: "nic"}},
+                "owner.salary": {relation: {entityName: "owner", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {owner: {entity: User, fieldName: "owner", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {[CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)};
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,64 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public type User record {|
+    readonly int id;
+    string name;
+    string nic;
+    decimal salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    string nic?;
+    decimal salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] car?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    string nic?;
+    decimal salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string make;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string make?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized owner?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string make?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/modules/postgresql_entities/script.sql
@@ -1,0 +1,17 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"make" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_95.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_95.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_72.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_72.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "owner.id": {relation: {entityName: "owner", refField: "id"}},
+                "owner.name": {relation: {entityName: "owner", refField: "name"}},
+                "owner.gender": {relation: {entityName: "owner", refField: "gender"}},
+                "owner.nic": {relation: {entityName: "owner", refField: "nic"}},
+                "owner.salary": {relation: {entityName: "owner", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {owner: {entity: User, fieldName: "owner", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized owner?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/mssql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "owner.id": {relation: {entityName: "owner", refField: "id"}},
+                "owner.name": {relation: {entityName: "owner", refField: "name"}},
+                "owner.gender": {relation: {entityName: "owner", refField: "gender"}},
+                "owner.nic": {relation: {entityName: "owner", refField: "nic"}},
+                "owner.salary": {relation: {entityName: "owner", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {owner: {entity: User, fieldName: "owner", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized owner?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/modules/postgresql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_72.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_72.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_73.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_73.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/entities/persist_client.bal
@@ -30,7 +30,7 @@ public isolated client class Client {
                 salary: {columnName: "salary"},
                 "cars[].id": {relation: {entityName: "cars", refField: "id"}},
                 "cars[].name": {relation: {entityName: "cars", refField: "name"}},
-                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model", refColumn: "MODEL"}},
                 "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
             },
             keyFields: ["id"],

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model", refColumn: "MODEL"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "cars", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "cars",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "MODEL"},
+                ownerId: {columnName: "ownerId"},
+                "owner.id": {relation: {entityName: "owner", refField: "id"}},
+                "owner.name": {relation: {entityName: "owner", refField: "name"}},
+                "owner.gender": {relation: {entityName: "owner", refField: "gender"}},
+                "owner.nic": {relation: {entityName: "owner", refField: "nic"}},
+                "owner.salary": {relation: {entityName: "owner", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {owner: {entity: User, fieldName: "owner", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized owner?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/mssql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [cars];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [cars] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[MODEL] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [cars] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model", refColumn: "MODEL"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "cars", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "cars",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "MODEL"},
+                ownerId: {columnName: "ownerId"},
+                "owner.id": {relation: {entityName: "owner", refField: "id"}},
+                "owner.name": {relation: {entityName: "owner", refField: "name"}},
+                "owner.gender": {relation: {entityName: "owner", refField: "gender"}},
+                "owner.nic": {relation: {entityName: "owner", refField: "nic"}},
+                "owner.salary": {relation: {entityName: "owner", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {owner: {entity: User, fieldName: "owner", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized owner?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/modules/postgresql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "cars";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "cars" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"MODEL" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "cars" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_73.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_73.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_74.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_74.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/entities/persist_client.bal
@@ -30,8 +30,8 @@ public isolated client class Client {
                 salary: {columnName: "salary"},
                 "cars[].id": {relation: {entityName: "cars", refField: "id"}},
                 "cars[].name": {relation: {entityName: "cars", refField: "name"}},
-                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
-                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+                "cars[].model": {relation: {entityName: "cars", refField: "model", refColumn: "MODEL"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}}
             },
             keyFields: ["id"],
             joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "cars", refColumns: ["OWNER_ID"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model", refColumn: "MODEL"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "cars", refColumns: ["OWNER_ID"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "cars",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "MODEL"},
+                ownerId: {columnName: "OWNER_ID"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["OWNER_ID"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/mssql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [cars];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [cars] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[MODEL] VARCHAR(191) NOT NULL,
+	[OWNER_ID] INT NOT NULL,
+	FOREIGN KEY([OWNER_ID]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [cars] ([OWNER_ID]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model", refColumn: "MODEL"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "cars", refColumns: ["OWNER_ID"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "cars",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "MODEL"},
+                ownerId: {columnName: "OWNER_ID"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["OWNER_ID"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/modules/postgresql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "cars";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "cars" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"MODEL" VARCHAR(191) NOT NULL,
+	"OWNER_ID" INT NOT NULL,
+	FOREIGN KEY("OWNER_ID") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "cars" ("OWNER_ID");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_74.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_74.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_75.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_75.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/mssql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(12) NOT NULL,
+	[salary] DECIMAL(10,2),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] CHAR(10) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/modules/postgresql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(12) NOT NULL,
+	"salary" DECIMAL(10,2),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" CHAR(10) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_75.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_75.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_76.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_76.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/mssql_entities/script.sql
@@ -1,0 +1,29 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE UNIQUE INDEX [nic_index] ON [User] ([nic]);
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/modules/postgresql_entities/script.sql
@@ -1,0 +1,29 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE UNIQUE INDEX "nic_index" ON "User" ("nic");
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_76.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_76.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_77.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_77.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/mssql_entities/script.sql
@@ -1,0 +1,29 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE UNIQUE INDEX [user_index] ON [User] ([id], [nic]);
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/modules/postgresql_entities/script.sql
@@ -1,0 +1,29 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE UNIQUE INDEX "user_index" ON "User" ("id", "nic");
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_77.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_77.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_78.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_78.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/mssql_entities/script.sql
@@ -1,0 +1,29 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [user_index] ON [User] ([id], [nic]);
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/modules/postgresql_entities/script.sql
@@ -1,0 +1,29 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "user_index" ON "User" ("id", "nic");
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_78.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_78.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_79.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_79.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/entities/persist_client.bal
@@ -44,7 +44,7 @@ public isolated client class Client {
                 name: {columnName: "name"},
                 model: {columnName: "model"},
                 ownerId: {columnName: "ownerId"},
-                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.id": {relation: {entityName: "user", refField: "id", refColumn: "ID"}},
                 "user.name": {relation: {entityName: "user", refField: "name"}},
                 "user.gender": {relation: {entityName: "user", refField: "gender"}},
                 "user.nic": {relation: {entityName: "user", refField: "nic"}},

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "USERS",
+            fieldMetadata: {
+                id: {columnName: "ID"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["ID"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id", refColumn: "ID"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "USERS", refColumns: ["ID"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/mssql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [USERS];
+
+CREATE TABLE [USERS] (
+	[ID] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([ID])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [USERS]([ID]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "USERS",
+            fieldMetadata: {
+                id: {columnName: "ID"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["ID"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id", refColumn: "ID"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "USERS", refColumns: ["ID"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/modules/postgresql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "USERS";
+
+CREATE TABLE "USERS" (
+	"ID" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("ID")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "USERS"("ID"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_79.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_79.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_80.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_80.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/entities/persist_client.bal
@@ -31,7 +31,7 @@ public isolated client class Client {
                 "cars[].id": {relation: {entityName: "cars", refField: "id"}},
                 "cars[].name": {relation: {entityName: "cars", refField: "name"}},
                 "cars[].model": {relation: {entityName: "cars", refField: "model"}},
-                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}}
             },
             keyFields: ["id"],
             joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["OWNER_ID"], joinColumns: ["ID"], 'type: psql:MANY_TO_ONE}}
@@ -44,7 +44,7 @@ public isolated client class Client {
                 name: {columnName: "name"},
                 model: {columnName: "model"},
                 ownerId: {columnName: "OWNER_ID"},
-                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.id": {relation: {entityName: "user", refField: "id", refColumn: "ID"}},
                 "user.name": {relation: {entityName: "user", refField: "name"}},
                 "user.gender": {relation: {entityName: "user", refField: "gender"}},
                 "user.nic": {relation: {entityName: "user", refField: "nic"}},

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "USERS",
+            fieldMetadata: {
+                id: {columnName: "ID"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["OWNER_ID"], joinColumns: ["ID"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "OWNER_ID"},
+                "user.id": {relation: {entityName: "user", refField: "id", refColumn: "ID"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "USERS", refColumns: ["ID"], joinColumns: ["OWNER_ID"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/mssql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [USERS];
+
+CREATE TABLE [USERS] (
+	[ID] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([ID])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[OWNER_ID] INT NOT NULL,
+	FOREIGN KEY([OWNER_ID]) REFERENCES [USERS]([ID]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [Car] ([OWNER_ID]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "USERS",
+            fieldMetadata: {
+                id: {columnName: "ID"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["OWNER_ID"], joinColumns: ["ID"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "OWNER_ID"},
+                "user.id": {relation: {entityName: "user", refField: "id", refColumn: "ID"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "USERS", refColumns: ["ID"], joinColumns: ["OWNER_ID"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/modules/postgresql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "USERS";
+
+CREATE TABLE "USERS" (
+	"ID" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("ID")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"OWNER_ID" INT NOT NULL,
+	FOREIGN KEY("OWNER_ID") REFERENCES "USERS"("ID"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "Car" ("OWNER_ID");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_80.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_80.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_81.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_81.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,166 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                nic: {columnName: "nic"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}},
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic"}}
+            },
+            keyFields: ["id", "nic"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId", "ownerNic"], joinColumns: ["id", "nic"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                ownerNic: {columnName: "ownerNic"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id", "nic"], joinColumns: ["ownerId", "ownerNic"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id]/[string nic](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns [int, string][]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select [inserted.id, inserted.nic];
+    }
+
+    isolated resource function put users/[int id]/[string nic](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery({"id": id, "nic": nic}, value);
+        return self->/users/[id]/[nic].get();
+    }
+
+    isolated resource function delete users/[int id]/[string nic]() returns User|persist:Error {
+        User result = check self->/users/[id]/[nic].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery({"id": id, "nic": nic});
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,74 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    readonly string nic;
+    string name;
+    UserGender gender;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string nic?;
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    string ownerNic;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/mssql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id],[nic])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	[ownerNic] VARCHAR(191) NOT NULL,
+	FOREIGN KEY([ownerId], [ownerNic]) REFERENCES [User]([id], [nic]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);
+CREATE INDEX [ownerNic] ON [Car] ([ownerNic]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,166 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                nic: {columnName: "nic"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}},
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic"}}
+            },
+            keyFields: ["id", "nic"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId", "ownerNic"], joinColumns: ["id", "nic"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                ownerNic: {columnName: "ownerNic"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id", "nic"], joinColumns: ["ownerId", "ownerNic"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id]/[string nic](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns [int, string][]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select [inserted.id, inserted.nic];
+    }
+
+    isolated resource function put users/[int id]/[string nic](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery({"id": id, "nic": nic}, value);
+        return self->/users/[id]/[nic].get();
+    }
+
+    isolated resource function delete users/[int id]/[string nic]() returns User|persist:Error {
+        User result = check self->/users/[id]/[nic].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery({"id": id, "nic": nic});
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,74 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    readonly string nic;
+    string name;
+    UserGender gender;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string nic?;
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    string ownerNic;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/modules/postgresql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id","nic")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	"ownerNic" VARCHAR(191) NOT NULL,
+	FOREIGN KEY("ownerId", "ownerNic") REFERENCES "User"("id", "nic"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "Car" ("ownerId");
+CREATE INDEX "ownerNic" ON "Car" ("ownerNic");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_81.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_81.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_82.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_82.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/entities/persist_client.bal
@@ -32,7 +32,7 @@ public isolated client class Client {
                 "cars[].name": {relation: {entityName: "cars", refField: "name"}},
                 "cars[].model": {relation: {entityName: "cars", refField: "model"}},
                 "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}},
-                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic"}}
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic", refColumn: "OWNER_NIC"}}
             },
             keyFields: ["id", "nic"],
             joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId", "OWNER_NIC"], joinColumns: ["id", "nic"], 'type: psql:MANY_TO_ONE}}

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,166 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                nic: {columnName: "nic"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}},
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic", refColumn: "OWNER_NIC"}}
+            },
+            keyFields: ["id", "nic"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId", "OWNER_NIC"], joinColumns: ["id", "nic"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                ownerNic: {columnName: "OWNER_NIC"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id", "nic"], joinColumns: ["ownerId", "OWNER_NIC"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id]/[string nic](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns [int, string][]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select [inserted.id, inserted.nic];
+    }
+
+    isolated resource function put users/[int id]/[string nic](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery({"id": id, "nic": nic}, value);
+        return self->/users/[id]/[nic].get();
+    }
+
+    isolated resource function delete users/[int id]/[string nic]() returns User|persist:Error {
+        User result = check self->/users/[id]/[nic].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery({"id": id, "nic": nic});
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,74 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    readonly string nic;
+    string name;
+    UserGender gender;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string nic?;
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    string ownerNic;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/mssql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id],[nic])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	[OWNER_NIC] VARCHAR(191) NOT NULL,
+	FOREIGN KEY([ownerId], [OWNER_NIC]) REFERENCES [User]([id], [nic]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);
+CREATE INDEX [ownerNic] ON [Car] ([OWNER_NIC]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,166 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                nic: {columnName: "nic"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}},
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic", refColumn: "OWNER_NIC"}}
+            },
+            keyFields: ["id", "nic"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId", "OWNER_NIC"], joinColumns: ["id", "nic"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                ownerNic: {columnName: "OWNER_NIC"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id", "nic"], joinColumns: ["ownerId", "OWNER_NIC"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id]/[string nic](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns [int, string][]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select [inserted.id, inserted.nic];
+    }
+
+    isolated resource function put users/[int id]/[string nic](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery({"id": id, "nic": nic}, value);
+        return self->/users/[id]/[nic].get();
+    }
+
+    isolated resource function delete users/[int id]/[string nic]() returns User|persist:Error {
+        User result = check self->/users/[id]/[nic].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery({"id": id, "nic": nic});
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,74 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    readonly string nic;
+    string name;
+    UserGender gender;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string nic?;
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    string ownerNic;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/modules/postgresql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id","nic")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	"OWNER_NIC" VARCHAR(191) NOT NULL,
+	FOREIGN KEY("ownerId", "OWNER_NIC") REFERENCES "User"("id", "nic"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "Car" ("ownerId");
+CREATE INDEX "ownerNic" ON "Car" ("OWNER_NIC");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_82.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_82.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_83.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_83.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/entities/persist_client.bal
@@ -31,8 +31,8 @@ public isolated client class Client {
                 "cars[].id": {relation: {entityName: "cars", refField: "id"}},
                 "cars[].name": {relation: {entityName: "cars", refField: "name"}},
                 "cars[].model": {relation: {entityName: "cars", refField: "model"}},
-                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}},
-                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic"}}
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}},
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic", refColumn: "OWNER_NIC"}}
             },
             keyFields: ["id", "nic"],
             joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["OWNER_ID", "OWNER_NIC"], joinColumns: ["id", "nic"], 'type: psql:MANY_TO_ONE}}

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,166 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                nic: {columnName: "nic"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}},
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic", refColumn: "OWNER_NIC"}}
+            },
+            keyFields: ["id", "nic"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["OWNER_ID", "OWNER_NIC"], joinColumns: ["id", "nic"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "OWNER_ID"},
+                ownerNic: {columnName: "OWNER_NIC"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id", "nic"], joinColumns: ["OWNER_ID", "OWNER_NIC"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id]/[string nic](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns [int, string][]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select [inserted.id, inserted.nic];
+    }
+
+    isolated resource function put users/[int id]/[string nic](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery({"id": id, "nic": nic}, value);
+        return self->/users/[id]/[nic].get();
+    }
+
+    isolated resource function delete users/[int id]/[string nic]() returns User|persist:Error {
+        User result = check self->/users/[id]/[nic].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery({"id": id, "nic": nic});
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,74 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    readonly string nic;
+    string name;
+    UserGender gender;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string nic?;
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    string ownerNic;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/mssql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id],[nic])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[OWNER_ID] INT NOT NULL,
+	[OWNER_NIC] VARCHAR(191) NOT NULL,
+	FOREIGN KEY([OWNER_ID], [OWNER_NIC]) REFERENCES [User]([id], [nic]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [Car] ([OWNER_ID]);
+CREATE INDEX [ownerNic] ON [Car] ([OWNER_NIC]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,166 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                nic: {columnName: "nic"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}},
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic", refColumn: "OWNER_NIC"}}
+            },
+            keyFields: ["id", "nic"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["OWNER_ID", "OWNER_NIC"], joinColumns: ["id", "nic"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "OWNER_ID"},
+                ownerNic: {columnName: "OWNER_NIC"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id", "nic"], joinColumns: ["OWNER_ID", "OWNER_NIC"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id]/[string nic](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns [int, string][]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select [inserted.id, inserted.nic];
+    }
+
+    isolated resource function put users/[int id]/[string nic](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery({"id": id, "nic": nic}, value);
+        return self->/users/[id]/[nic].get();
+    }
+
+    isolated resource function delete users/[int id]/[string nic]() returns User|persist:Error {
+        User result = check self->/users/[id]/[nic].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery({"id": id, "nic": nic});
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,74 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    readonly string nic;
+    string name;
+    UserGender gender;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string nic?;
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    string ownerNic;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/modules/postgresql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id","nic")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"OWNER_ID" INT NOT NULL,
+	"OWNER_NIC" VARCHAR(191) NOT NULL,
+	FOREIGN KEY("OWNER_ID", "OWNER_NIC") REFERENCES "User"("id", "nic"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "Car" ("OWNER_ID");
+CREATE INDEX "ownerNic" ON "Car" ("OWNER_NIC");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_83.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_83.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_84.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_84.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/entities/persist_client.bal
@@ -31,8 +31,8 @@ public isolated client class Client {
                 "cars[].id": {relation: {entityName: "cars", refField: "id"}},
                 "cars[].name": {relation: {entityName: "cars", refField: "name"}},
                 "cars[].model": {relation: {entityName: "cars", refField: "model"}},
-                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}},
-                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic"}}
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}},
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic", refColumn: "OWNER_NIC"}}
             },
             keyFields: ["id", "nic"],
             joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["OWNER_ID", "OWNER_NIC"], joinColumns: ["id", "NIC"], 'type: psql:MANY_TO_ONE}}
@@ -47,7 +47,7 @@ public isolated client class Client {
                 ownerId: {columnName: "OWNER_ID"},
                 ownerNic: {columnName: "OWNER_NIC"},
                 "user.id": {relation: {entityName: "user", refField: "id"}},
-                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic", refColumn: "NIC"}},
                 "user.name": {relation: {entityName: "user", refField: "name"}},
                 "user.gender": {relation: {entityName: "user", refField: "gender"}},
                 "user.salary": {relation: {entityName: "user", refField: "salary"}}

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,166 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                nic: {columnName: "NIC"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}},
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic", refColumn: "OWNER_NIC"}}
+            },
+            keyFields: ["id", "nic"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["OWNER_ID", "OWNER_NIC"], joinColumns: ["id", "NIC"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "OWNER_ID"},
+                ownerNic: {columnName: "OWNER_NIC"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic", refColumn: "NIC"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id", "NIC"], joinColumns: ["OWNER_ID", "OWNER_NIC"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id]/[string nic](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns [int, string][]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select [inserted.id, inserted.nic];
+    }
+
+    isolated resource function put users/[int id]/[string nic](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery({"id": id, "nic": nic}, value);
+        return self->/users/[id]/[nic].get();
+    }
+
+    isolated resource function delete users/[int id]/[string nic]() returns User|persist:Error {
+        User result = check self->/users/[id]/[nic].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery({"id": id, "nic": nic});
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,74 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    readonly string nic;
+    string name;
+    UserGender gender;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string nic?;
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    string ownerNic;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/mssql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[NIC] VARCHAR(191) NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id],[NIC])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[OWNER_ID] INT NOT NULL,
+	[OWNER_NIC] VARCHAR(191) NOT NULL,
+	FOREIGN KEY([OWNER_ID], [OWNER_NIC]) REFERENCES [User]([id], [NIC]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [Car] ([OWNER_ID]);
+CREATE INDEX [ownerNic] ON [Car] ([OWNER_NIC]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,166 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                nic: {columnName: "NIC"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}},
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic", refColumn: "OWNER_NIC"}}
+            },
+            keyFields: ["id", "nic"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["OWNER_ID", "OWNER_NIC"], joinColumns: ["id", "NIC"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "OWNER_ID"},
+                ownerNic: {columnName: "OWNER_NIC"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic", refColumn: "NIC"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id", "NIC"], joinColumns: ["OWNER_ID", "OWNER_NIC"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id]/[string nic](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns [int, string][]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select [inserted.id, inserted.nic];
+    }
+
+    isolated resource function put users/[int id]/[string nic](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery({"id": id, "nic": nic}, value);
+        return self->/users/[id]/[nic].get();
+    }
+
+    isolated resource function delete users/[int id]/[string nic]() returns User|persist:Error {
+        User result = check self->/users/[id]/[nic].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery({"id": id, "nic": nic});
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,74 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    readonly string nic;
+    string name;
+    UserGender gender;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string nic?;
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    string ownerNic;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/modules/postgresql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"NIC" VARCHAR(191) NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id","NIC")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"OWNER_ID" INT NOT NULL,
+	"OWNER_NIC" VARCHAR(191) NOT NULL,
+	FOREIGN KEY("OWNER_ID", "OWNER_NIC") REFERENCES "User"("id", "NIC"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "Car" ("OWNER_ID");
+CREATE INDEX "ownerNic" ON "Car" ("OWNER_NIC");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_84.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_84.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_85.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_85.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/entities/persist_client.bal
@@ -31,8 +31,8 @@ public isolated client class Client {
                 "cars[].id": {relation: {entityName: "cars", refField: "id"}},
                 "cars[].name": {relation: {entityName: "cars", refField: "name"}},
                 "cars[].model": {relation: {entityName: "cars", refField: "model"}},
-                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}},
-                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic"}}
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}},
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic", refColumn: "OWNER_NIC"}}
             },
             keyFields: ["id", "nic"],
             joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["OWNER_ID", "OWNER_NIC"], joinColumns: ["ID", "NIC"], 'type: psql:MANY_TO_ONE}}
@@ -46,8 +46,8 @@ public isolated client class Client {
                 model: {columnName: "model"},
                 ownerId: {columnName: "OWNER_ID"},
                 ownerNic: {columnName: "OWNER_NIC"},
-                "user.id": {relation: {entityName: "user", refField: "id"}},
-                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.id": {relation: {entityName: "user", refField: "id", refColumn: "ID"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic", refColumn: "NIC"}},
                 "user.name": {relation: {entityName: "user", refField: "name"}},
                 "user.gender": {relation: {entityName: "user", refField: "gender"}},
                 "user.salary": {relation: {entityName: "user", refField: "salary"}}

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,166 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "ID"},
+                nic: {columnName: "NIC"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}},
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic", refColumn: "OWNER_NIC"}}
+            },
+            keyFields: ["id", "nic"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["OWNER_ID", "OWNER_NIC"], joinColumns: ["ID", "NIC"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "OWNER_ID"},
+                ownerNic: {columnName: "OWNER_NIC"},
+                "user.id": {relation: {entityName: "user", refField: "id", refColumn: "ID"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic", refColumn: "NIC"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["ID", "NIC"], joinColumns: ["OWNER_ID", "OWNER_NIC"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id]/[string nic](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns [int, string][]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select [inserted.id, inserted.nic];
+    }
+
+    isolated resource function put users/[int id]/[string nic](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery({"id": id, "nic": nic}, value);
+        return self->/users/[id]/[nic].get();
+    }
+
+    isolated resource function delete users/[int id]/[string nic]() returns User|persist:Error {
+        User result = check self->/users/[id]/[nic].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery({"id": id, "nic": nic});
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,74 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    readonly string nic;
+    string name;
+    UserGender gender;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string nic?;
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    string ownerNic;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/mssql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[ID] INT NOT NULL,
+	[NIC] VARCHAR(191) NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([ID],[NIC])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[OWNER_ID] INT NOT NULL,
+	[OWNER_NIC] VARCHAR(191) NOT NULL,
+	FOREIGN KEY([OWNER_ID], [OWNER_NIC]) REFERENCES [User]([ID], [NIC]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [Car] ([OWNER_ID]);
+CREATE INDEX [ownerNic] ON [Car] ([OWNER_NIC]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,166 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "ID"},
+                nic: {columnName: "NIC"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId", refColumn: "OWNER_ID"}},
+                "cars[].ownerNic": {relation: {entityName: "cars", refField: "ownerNic", refColumn: "OWNER_NIC"}}
+            },
+            keyFields: ["id", "nic"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["OWNER_ID", "OWNER_NIC"], joinColumns: ["ID", "NIC"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "OWNER_ID"},
+                ownerNic: {columnName: "OWNER_NIC"},
+                "user.id": {relation: {entityName: "user", refField: "id", refColumn: "ID"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic", refColumn: "NIC"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["ID", "NIC"], joinColumns: ["OWNER_ID", "OWNER_NIC"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id]/[string nic](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns [int, string][]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select [inserted.id, inserted.nic];
+    }
+
+    isolated resource function put users/[int id]/[string nic](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery({"id": id, "nic": nic}, value);
+        return self->/users/[id]/[nic].get();
+    }
+
+    isolated resource function delete users/[int id]/[string nic]() returns User|persist:Error {
+        User result = check self->/users/[id]/[nic].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery({"id": id, "nic": nic});
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,74 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    readonly string nic;
+    string name;
+    UserGender gender;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string nic?;
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    string ownerNic;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    string ownerNic?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/modules/postgresql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"ID" INT NOT NULL,
+	"NIC" VARCHAR(191) NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("ID","NIC")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"OWNER_ID" INT NOT NULL,
+	"OWNER_NIC" VARCHAR(191) NOT NULL,
+	FOREIGN KEY("OWNER_ID", "OWNER_NIC") REFERENCES "User"("ID", "NIC"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "Car" ("OWNER_ID");
+CREATE INDEX "ownerNic" ON "Car" ("OWNER_NIC");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_85.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_85.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_86.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_86.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/mssql_entities/script.sql
@@ -1,0 +1,29 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [idx_nic] ON [User] ([nic]);
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/modules/postgresql_entities/script.sql
@@ -1,0 +1,29 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "idx_nic" ON "User" ("nic");
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_86.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_86.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_87.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_87.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/mssql_entities/script.sql
@@ -1,0 +1,29 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE UNIQUE INDEX [unique_idx_nic] ON [User] ([nic]);
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/modules/postgresql_entities/script.sql
@@ -1,0 +1,29 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE UNIQUE INDEX "unique_idx_nic" ON "User" ("nic");
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_87.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_87.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_88.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_88.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/mssql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [idx_nic] ON [User] ([nic]);
+CREATE UNIQUE INDEX [unique_idx_nic] ON [User] ([nic]);
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/modules/postgresql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "idx_nic" ON "User" ("nic");
+CREATE UNIQUE INDEX "unique_idx_nic" ON "User" ("nic");
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_88.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_88.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_89.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_89.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/mssql_entities/script.sql
@@ -1,0 +1,31 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [idx_nic] ON [User] ([nic]);
+CREATE UNIQUE INDEX [unique_user] ON [User] ([id], [nic]);
+CREATE UNIQUE INDEX [unique_nic] ON [User] ([nic]);
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,164 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/modules/postgresql_entities/script.sql
@@ -1,0 +1,31 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "idx_nic" ON "User" ("nic");
+CREATE UNIQUE INDEX "unique_user" ON "User" ("id", "nic");
+CREATE UNIQUE INDEX "unique_nic" ON "User" ("nic");
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_89.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_89.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/Config.toml
@@ -5,3 +5,17 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_90.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_90.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/entities/persist_client.bal
@@ -22,7 +22,7 @@ public isolated client class Client {
             entityName: "User",
             tableName: "User",
             fieldMetadata: {
-                id: {columnName: "id"},
+                id: {columnName: "id", dbGenerated: true},
                 name: {columnName: "name"},
                 gender: {columnName: "gender"},
                 nic: {columnName: "nic"},

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,100 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id", dbGenerated: true},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"}
+            },
+            keyFields: ["id"]
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {[USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS)};
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        sql:ExecutionResult[] result = check sqlClient.runBatchInsertQuery(data);
+        return from sql:ExecutionResult inserted in result
+            where inserted.lastInsertId != ()
+            select <int>inserted.lastInsertId;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,42 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserTargetType typedesc<UserOptionalized>;
+
+public type UserInsert record {|
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+|};
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/mssql_entities/script.sql
@@ -1,0 +1,17 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT IDENTITY(1,1),
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,100 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id", dbGenerated: true},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"}
+            },
+            keyFields: ["id"]
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {[USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS)};
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        sql:ExecutionResult[] result = check sqlClient.runBatchInsertQuery(data);
+        return from sql:ExecutionResult inserted in result
+            where inserted.lastInsertId != ()
+            select <int>inserted.lastInsertId;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,42 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserTargetType typedesc<UserOptionalized>;
+
+public type UserInsert record {|
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+|};
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/modules/postgresql_entities/script.sql
@@ -1,0 +1,17 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id"  SERIAL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_90.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_90.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_91.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_91.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/entities/persist_client.bal
@@ -23,7 +23,7 @@ public isolated client class Client {
             entityName: "User",
             tableName: "User",
             fieldMetadata: {
-                id: {columnName: "id"},
+                id: {columnName: "id", dbGenerated: true},
                 name: {columnName: "name"},
                 gender: {columnName: "gender"},
                 nic: {columnName: "nic"},

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,165 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id", dbGenerated: true},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        sql:ExecutionResult[] result = check sqlClient.runBatchInsertQuery(data);
+        return from sql:ExecutionResult inserted in result
+            where inserted.lastInsertId != ()
+            select <int>inserted.lastInsertId;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,77 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert record {|
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+|};
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/mssql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT IDENTITY(1,1),
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,165 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id", dbGenerated: true},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        sql:ExecutionResult[] result = check sqlClient.runBatchInsertQuery(data);
+        return from sql:ExecutionResult inserted in result
+            where inserted.lastInsertId != ()
+            select <int>inserted.lastInsertId;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,77 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert record {|
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+|};
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/modules/postgresql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id"  SERIAL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_91.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_91.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_92.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_92.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/entities/persist_client.bal
@@ -23,7 +23,7 @@ public isolated client class Client {
             entityName: "User",
             tableName: "User",
             fieldMetadata: {
-                id: {columnName: "ID"},
+                id: {columnName: "ID", dbGenerated: true},
                 name: {columnName: "name"},
                 gender: {columnName: "gender"},
                 nic: {columnName: "nic"},
@@ -44,7 +44,7 @@ public isolated client class Client {
                 name: {columnName: "name"},
                 model: {columnName: "model"},
                 ownerId: {columnName: "ownerId"},
-                "user.id": {relation: {entityName: "user", refField: "id"}},
+                "user.id": {relation: {entityName: "user", refField: "id", refColumn: "ID"}},
                 "user.name": {relation: {entityName: "user", refField: "name"}},
                 "user.gender": {relation: {entityName: "user", refField: "gender"}},
                 "user.nic": {relation: {entityName: "user", refField: "nic"}},

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,165 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "ID", dbGenerated: true},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["ID"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id", refColumn: "ID"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["ID"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        sql:ExecutionResult[] result = check sqlClient.runBatchInsertQuery(data);
+        return from sql:ExecutionResult inserted in result
+            where inserted.lastInsertId != ()
+            select <int>inserted.lastInsertId;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,77 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert record {|
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+|};
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/mssql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[ID] INT IDENTITY(1,1),
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([ID])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([ID]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,165 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "ID", dbGenerated: true},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["ID"], 'type: psql:MANY_TO_ONE}}
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                "user.id": {relation: {entityName: "user", refField: "id", refColumn: "ID"}},
+                "user.name": {relation: {entityName: "user", refField: "name"}},
+                "user.gender": {relation: {entityName: "user", refField: "gender"}},
+                "user.nic": {relation: {entityName: "user", refField: "nic"}},
+                "user.salary": {relation: {entityName: "user", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {user: {entity: User, fieldName: "user", refTable: "User", refColumns: ["ID"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY}}
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        sql:ExecutionResult[] result = check sqlClient.runBatchInsertQuery(data);
+        return from sql:ExecutionResult inserted in result
+            where inserted.lastInsertId != ()
+            select <int>inserted.lastInsertId;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,77 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert record {|
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+|};
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized user?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/modules/postgresql_entities/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"ID"  SERIAL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("ID")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("ID"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_92.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_92.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_93.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_93.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,182 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}},
+                "cars[].driverId": {relation: {entityName: "cars", refField: "driverId"}},
+                "drives.id": {relation: {entityName: "drives", refField: "id"}},
+                "drives.name": {relation: {entityName: "drives", refField: "name"}},
+                "drives.model": {relation: {entityName: "drives", refField: "model"}},
+                "drives.ownerId": {relation: {entityName: "drives", refField: "ownerId"}},
+                "drives.driverId": {relation: {entityName: "drives", refField: "driverId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {
+                cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE},
+                drives: {entity: Car, fieldName: "drives", refTable: "Car", refColumns: ["driverId"], joinColumns: ["id"], 'type: psql:ONE_TO_ONE}
+            }
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                driverId: {columnName: "driverId"},
+                "owner.id": {relation: {entityName: "owner", refField: "id"}},
+                "owner.name": {relation: {entityName: "owner", refField: "name"}},
+                "owner.gender": {relation: {entityName: "owner", refField: "gender"}},
+                "owner.nic": {relation: {entityName: "owner", refField: "nic"}},
+                "owner.salary": {relation: {entityName: "owner", refField: "salary"}},
+                "driver.id": {relation: {entityName: "driver", refField: "id"}},
+                "driver.name": {relation: {entityName: "driver", refField: "name"}},
+                "driver.gender": {relation: {entityName: "driver", refField: "gender"}},
+                "driver.nic": {relation: {entityName: "driver", refField: "nic"}},
+                "driver.salary": {relation: {entityName: "driver", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {
+                owner: {entity: User, fieldName: "owner", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY},
+                driver: {entity: User, fieldName: "driver", refTable: "User", refColumns: ["id"], joinColumns: ["driverId"], 'type: psql:ONE_TO_MANY}
+            }
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,77 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+    CarOptionalized drives?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    int driverId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    int driverId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized owner?;
+    UserOptionalized driver?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    int driverId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/mssql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	[driverId] INT NOT NULL,
+	FOREIGN KEY([driverId]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,182 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}},
+                "cars[].driverId": {relation: {entityName: "cars", refField: "driverId"}},
+                "drives.id": {relation: {entityName: "drives", refField: "id"}},
+                "drives.name": {relation: {entityName: "drives", refField: "name"}},
+                "drives.model": {relation: {entityName: "drives", refField: "model"}},
+                "drives.ownerId": {relation: {entityName: "drives", refField: "ownerId"}},
+                "drives.driverId": {relation: {entityName: "drives", refField: "driverId"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {
+                cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE},
+                drives: {entity: Car, fieldName: "drives", refTable: "Car", refColumns: ["driverId"], joinColumns: ["id"], 'type: psql:ONE_TO_ONE}
+            }
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                driverId: {columnName: "driverId"},
+                "owner.id": {relation: {entityName: "owner", refField: "id"}},
+                "owner.name": {relation: {entityName: "owner", refField: "name"}},
+                "owner.gender": {relation: {entityName: "owner", refField: "gender"}},
+                "owner.nic": {relation: {entityName: "owner", refField: "nic"}},
+                "owner.salary": {relation: {entityName: "owner", refField: "salary"}},
+                "driver.id": {relation: {entityName: "driver", refField: "id"}},
+                "driver.name": {relation: {entityName: "driver", refField: "name"}},
+                "driver.gender": {relation: {entityName: "driver", refField: "gender"}},
+                "driver.nic": {relation: {entityName: "driver", refField: "nic"}},
+                "driver.salary": {relation: {entityName: "driver", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {
+                owner: {entity: User, fieldName: "owner", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY},
+                driver: {entity: User, fieldName: "driver", refTable: "User", refColumns: ["id"], joinColumns: ["driverId"], 'type: psql:ONE_TO_MANY}
+            }
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,77 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+    CarOptionalized drives?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    int driverId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    int driverId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized owner?;
+    UserOptionalized driver?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    int driverId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/modules/postgresql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	"driverId" INT NOT NULL,
+	FOREIGN KEY("driverId") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_93.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_93.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/Config.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/Config.toml
@@ -5,3 +5,18 @@ user = "root"
 password = ""
 database = ""
 
+[tool_test_generate_94.mssql_entities]
+host = "localhost"
+port = 1433
+user = "sa"
+password = ""
+database = ""
+
+[tool_test_generate_94.postgresql_entities]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = ""
+database = ""
+
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/entities/persist_client.bal
@@ -32,12 +32,12 @@ public isolated client class Client {
                 "cars[].name": {relation: {entityName: "cars", refField: "name"}},
                 "cars[].model": {relation: {entityName: "cars", refField: "model"}},
                 "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}},
-                "cars[].driverId": {relation: {entityName: "cars", refField: "driverId"}},
+                "cars[].driverId": {relation: {entityName: "cars", refField: "driverId", refColumn: "DRIVER_ID"}},
                 "drives.id": {relation: {entityName: "drives", refField: "id"}},
                 "drives.name": {relation: {entityName: "drives", refField: "name"}},
                 "drives.model": {relation: {entityName: "drives", refField: "model"}},
                 "drives.ownerId": {relation: {entityName: "drives", refField: "ownerId"}},
-                "drives.driverId": {relation: {entityName: "drives", refField: "driverId"}}
+                "drives.driverId": {relation: {entityName: "drives", refField: "driverId", refColumn: "DRIVER_ID"}}
             },
             keyFields: ["id"],
             joinMetadata: {

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/mssql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/mssql_entities/persist_client.bal
@@ -1,0 +1,182 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/mssql;
+import ballerinax/mssql.driver as _;
+import ballerinax/persist.sql as psql;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final mssql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}},
+                "cars[].driverId": {relation: {entityName: "cars", refField: "driverId", refColumn: "DRIVER_ID"}},
+                "drives.id": {relation: {entityName: "drives", refField: "id"}},
+                "drives.name": {relation: {entityName: "drives", refField: "name"}},
+                "drives.model": {relation: {entityName: "drives", refField: "model"}},
+                "drives.ownerId": {relation: {entityName: "drives", refField: "ownerId"}},
+                "drives.driverId": {relation: {entityName: "drives", refField: "driverId", refColumn: "DRIVER_ID"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {
+                cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE},
+                drives: {entity: Car, fieldName: "drives", refTable: "Car", refColumns: ["DRIVER_ID"], joinColumns: ["id"], 'type: psql:ONE_TO_ONE}
+            }
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                driverId: {columnName: "DRIVER_ID"},
+                "owner.id": {relation: {entityName: "owner", refField: "id"}},
+                "owner.name": {relation: {entityName: "owner", refField: "name"}},
+                "owner.gender": {relation: {entityName: "owner", refField: "gender"}},
+                "owner.nic": {relation: {entityName: "owner", refField: "nic"}},
+                "owner.salary": {relation: {entityName: "owner", refField: "salary"}},
+                "driver.id": {relation: {entityName: "driver", refField: "id"}},
+                "driver.name": {relation: {entityName: "driver", refField: "name"}},
+                "driver.gender": {relation: {entityName: "driver", refField: "gender"}},
+                "driver.nic": {relation: {entityName: "driver", refField: "nic"}},
+                "driver.salary": {relation: {entityName: "driver", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {
+                owner: {entity: User, fieldName: "owner", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY},
+                driver: {entity: User, fieldName: "driver", refTable: "User", refColumns: ["id"], joinColumns: ["DRIVER_ID"], 'type: psql:ONE_TO_MANY}
+            }
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        mssql:Client|error dbClient = new (host = host, user = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:MSSQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:MSSQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.MSSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/mssql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/mssql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/mssql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable mssql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/mssql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/mssql_entities/persist_types.bal
@@ -1,0 +1,77 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+    CarOptionalized drives?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    int driverId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    int driverId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized owner?;
+    UserOptionalized driver?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    int driverId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/mssql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/mssql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS [Car];
+DROP TABLE IF EXISTS [User];
+
+CREATE TABLE [User] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[gender] VARCHAR(6) CHECK ([gender] IN ('MALE', 'FEMALE')) NOT NULL,
+	[nic] VARCHAR(191) NOT NULL,
+	[salary] DECIMAL(38,30),
+	PRIMARY KEY([id])
+);
+
+CREATE TABLE [Car] (
+	[id] INT NOT NULL,
+	[name] VARCHAR(191) NOT NULL,
+	[model] VARCHAR(191) NOT NULL,
+	[ownerId] INT NOT NULL,
+	FOREIGN KEY([ownerId]) REFERENCES [User]([id]),
+	[DRIVER_ID] INT NOT NULL,
+	FOREIGN KEY([DRIVER_ID]) REFERENCES [User]([id]),
+	PRIMARY KEY([id])
+);
+
+
+CREATE INDEX [ownerId] ON [Car] ([ownerId]);

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/postgresql_entities/persist_client.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/postgresql_entities/persist_client.bal
@@ -1,0 +1,182 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+import ballerina/jballerina.java;
+import ballerina/persist;
+import ballerina/sql;
+import ballerinax/persist.sql as psql;
+import ballerinax/postgresql;
+import ballerinax/postgresql.driver as _;
+
+const USER = "users";
+const CAR = "cars";
+
+public isolated client class Client {
+    *persist:AbstractPersistClient;
+
+    private final postgresql:Client dbClient;
+
+    private final map<psql:SQLClient> persistClients;
+
+    private final record {|psql:SQLMetadata...;|} & readonly metadata = {
+        [USER]: {
+            entityName: "User",
+            tableName: "User",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                gender: {columnName: "gender"},
+                nic: {columnName: "nic"},
+                salary: {columnName: "salary"},
+                "cars[].id": {relation: {entityName: "cars", refField: "id"}},
+                "cars[].name": {relation: {entityName: "cars", refField: "name"}},
+                "cars[].model": {relation: {entityName: "cars", refField: "model"}},
+                "cars[].ownerId": {relation: {entityName: "cars", refField: "ownerId"}},
+                "cars[].driverId": {relation: {entityName: "cars", refField: "driverId", refColumn: "DRIVER_ID"}},
+                "drives.id": {relation: {entityName: "drives", refField: "id"}},
+                "drives.name": {relation: {entityName: "drives", refField: "name"}},
+                "drives.model": {relation: {entityName: "drives", refField: "model"}},
+                "drives.ownerId": {relation: {entityName: "drives", refField: "ownerId"}},
+                "drives.driverId": {relation: {entityName: "drives", refField: "driverId", refColumn: "DRIVER_ID"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {
+                cars: {entity: Car, fieldName: "cars", refTable: "Car", refColumns: ["ownerId"], joinColumns: ["id"], 'type: psql:MANY_TO_ONE},
+                drives: {entity: Car, fieldName: "drives", refTable: "Car", refColumns: ["DRIVER_ID"], joinColumns: ["id"], 'type: psql:ONE_TO_ONE}
+            }
+        },
+        [CAR]: {
+            entityName: "Car",
+            tableName: "Car",
+            fieldMetadata: {
+                id: {columnName: "id"},
+                name: {columnName: "name"},
+                model: {columnName: "model"},
+                ownerId: {columnName: "ownerId"},
+                driverId: {columnName: "DRIVER_ID"},
+                "owner.id": {relation: {entityName: "owner", refField: "id"}},
+                "owner.name": {relation: {entityName: "owner", refField: "name"}},
+                "owner.gender": {relation: {entityName: "owner", refField: "gender"}},
+                "owner.nic": {relation: {entityName: "owner", refField: "nic"}},
+                "owner.salary": {relation: {entityName: "owner", refField: "salary"}},
+                "driver.id": {relation: {entityName: "driver", refField: "id"}},
+                "driver.name": {relation: {entityName: "driver", refField: "name"}},
+                "driver.gender": {relation: {entityName: "driver", refField: "gender"}},
+                "driver.nic": {relation: {entityName: "driver", refField: "nic"}},
+                "driver.salary": {relation: {entityName: "driver", refField: "salary"}}
+            },
+            keyFields: ["id"],
+            joinMetadata: {
+                owner: {entity: User, fieldName: "owner", refTable: "User", refColumns: ["id"], joinColumns: ["ownerId"], 'type: psql:ONE_TO_MANY},
+                driver: {entity: User, fieldName: "driver", refTable: "User", refColumns: ["id"], joinColumns: ["DRIVER_ID"], 'type: psql:ONE_TO_MANY}
+            }
+        }
+    };
+
+    public isolated function init() returns persist:Error? {
+        postgresql:Client|error dbClient = new (host = host, username = user, password = password, database = database, port = port, options = connectionOptions);
+        if dbClient is error {
+            return <persist:Error>error(dbClient.message());
+        }
+        self.dbClient = dbClient;
+        self.persistClients = {
+            [USER]: check new (dbClient, self.metadata.get(USER), psql:POSTGRESQL_SPECIFICS),
+            [CAR]: check new (dbClient, self.metadata.get(CAR), psql:POSTGRESQL_SPECIFICS)
+        };
+    }
+
+    isolated resource function get users(UserTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get users/[int id](UserTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post users(UserInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from UserInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put users/[int id](UserUpdate value) returns User|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/users/[id].get();
+    }
+
+    isolated resource function delete users/[int id]() returns User|persist:Error {
+        User result = check self->/users/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(USER);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    isolated resource function get cars(CarTargetType targetType = <>, sql:ParameterizedQuery whereClause = ``, sql:ParameterizedQuery orderByClause = ``, sql:ParameterizedQuery limitClause = ``, sql:ParameterizedQuery groupByClause = ``) returns stream<targetType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "query"
+    } external;
+
+    isolated resource function get cars/[int id](CarTargetType targetType = <>) returns targetType|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor",
+        name: "queryOne"
+    } external;
+
+    isolated resource function post cars(CarInsert[] data) returns int[]|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runBatchInsertQuery(data);
+        return from CarInsert inserted in data
+            select inserted.id;
+    }
+
+    isolated resource function put cars/[int id](CarUpdate value) returns Car|persist:Error {
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runUpdateQuery(id, value);
+        return self->/cars/[id].get();
+    }
+
+    isolated resource function delete cars/[int id]() returns Car|persist:Error {
+        Car result = check self->/cars/[id].get();
+        psql:SQLClient sqlClient;
+        lock {
+            sqlClient = self.persistClients.get(CAR);
+        }
+        _ = check sqlClient.runDeleteQuery(id);
+        return result;
+    }
+
+    remote isolated function queryNativeSQL(sql:ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>) returns stream<rowType, persist:Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    remote isolated function executeNativeSQL(sql:ParameterizedQuery sqlQuery) returns psql:ExecutionResult|persist:Error = @java:Method {
+        'class: "io.ballerina.stdlib.persist.sql.datastore.PostgreSQLProcessor"
+    } external;
+
+    public isolated function close() returns persist:Error? {
+        error? result = self.dbClient.close();
+        if result is error {
+            return <persist:Error>error(result.message());
+        }
+        return result;
+    }
+}
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/postgresql_entities/persist_db_config.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/postgresql_entities/persist_db_config.bal
@@ -1,0 +1,12 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+// This file is an auto-generated file by Ballerina persistence layer.
+// It should not be modified by hand.
+import ballerinax/postgresql;
+
+configurable int port = ?;
+configurable string host = ?;
+configurable string user = ?;
+configurable string database = ?;
+configurable string password = ?;
+configurable postgresql:Options & readonly connectionOptions = {};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/postgresql_entities/persist_types.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/postgresql_entities/persist_types.bal
@@ -1,0 +1,77 @@
+// AUTO-GENERATED FILE. DO NOT MODIFY.
+
+// This file is an auto-generated file by Ballerina persistence layer for model.
+// It should not be modified by hand.
+
+public enum UserGender {
+    MALE,
+    FEMALE
+}
+
+public type User record {|
+    readonly int id;
+    string name;
+    UserGender gender;
+    string nic;
+    decimal? salary;
+
+|};
+
+public type UserOptionalized record {|
+    int id?;
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type UserWithRelations record {|
+    *UserOptionalized;
+    CarOptionalized[] cars?;
+    CarOptionalized drives?;
+|};
+
+public type UserTargetType typedesc<UserWithRelations>;
+
+public type UserInsert User;
+
+public type UserUpdate record {|
+    string name?;
+    UserGender gender?;
+    string nic?;
+    decimal? salary?;
+|};
+
+public type Car record {|
+    readonly int id;
+    string name;
+    string model;
+    int ownerId;
+    int driverId;
+|};
+
+public type CarOptionalized record {|
+    int id?;
+    string name?;
+    string model?;
+    int ownerId?;
+    int driverId?;
+|};
+
+public type CarWithRelations record {|
+    *CarOptionalized;
+    UserOptionalized owner?;
+    UserOptionalized driver?;
+|};
+
+public type CarTargetType typedesc<CarWithRelations>;
+
+public type CarInsert Car;
+
+public type CarUpdate record {|
+    string name?;
+    string model?;
+    int ownerId?;
+    int driverId?;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/postgresql_entities/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/modules/postgresql_entities/script.sql
@@ -1,0 +1,30 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for model.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS "Car";
+DROP TABLE IF EXISTS "User";
+
+CREATE TABLE "User" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"gender" VARCHAR(6) CHECK ("gender" IN ('MALE', 'FEMALE')) NOT NULL,
+	"nic" VARCHAR(191) NOT NULL,
+	"salary" DECIMAL(65,30),
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE "Car" (
+	"id" INT NOT NULL,
+	"name" VARCHAR(191) NOT NULL,
+	"model" VARCHAR(191) NOT NULL,
+	"ownerId" INT NOT NULL,
+	FOREIGN KEY("ownerId") REFERENCES "User"("id"),
+	"DRIVER_ID" INT NOT NULL,
+	FOREIGN KEY("DRIVER_ID") REFERENCES "User"("id"),
+	PRIMARY KEY("id")
+);
+
+
+CREATE INDEX "ownerId" ON "Car" ("ownerId");

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/target/Persist.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/target/Persist.toml
@@ -1,3 +1,3 @@
 [[tool.persist]]
-options.datastore = "mysql"
-module = "tool_test_generate_94.entities"
+options.datastore = "postgresql"
+module = "tool_test_generate_94.postgresql_entities"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/Ballerina.toml
@@ -1,0 +1,20 @@
+[package]
+org = "wso2"
+name = "persistTest7"
+version = "0.1.0"
+distribution = "2201.5.0"
+
+[build-options]
+observabilityIncluded = true
+
+[[tool.persist]]
+id = "persist"
+options.datastore = "mysql"
+targetModule = "persistTest7"
+filePath = "persist/model.bal"
+
+[[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "persist-native"
+version = "0.3.0"
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/main.bal
@@ -1,0 +1,5 @@
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/main.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/io;
 
 public function main() {

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/persist/migrations/20230516081311_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/persist/migrations/20230516081311_firstMigration/model.bal
@@ -1,0 +1,23 @@
+import ballerina/persist as _;
+import ballerina/time;
+
+public type MedicalNeed record {|
+    readonly int id;
+
+    int needId;
+    string itemId;
+    string name;
+    time:Civil period;
+    MedicalItem[] items;
+|};
+
+public type MedicalItem record {|
+    readonly string name;
+
+    int itemId;
+    string decrip;
+    string unit;
+    int num;
+    MedicalNeed need;
+|};
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/persist/migrations/20230516081311_firstMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/persist/migrations/20230516081311_firstMigration/script.sql
@@ -1,0 +1,28 @@
+-- AUTO-GENERATED FILE.
+
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+DROP TABLE IF EXISTS `MedicalItem`;
+DROP TABLE IF EXISTS `MedicalNeed`;
+
+CREATE TABLE `MedicalNeed` (
+	`id` INT NOT NULL,
+	`needId` INT NOT NULL,
+	`itemId` VARCHAR(191) NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`period` DATETIME NOT NULL,
+	PRIMARY KEY(`id`)
+);
+
+CREATE TABLE `MedicalItem` (
+	`name` VARCHAR(191) NOT NULL,
+	`itemId` INT NOT NULL,
+	`decrip` VARCHAR(191) NOT NULL,
+	`unit` VARCHAR(191) NOT NULL,
+	`num` INT NOT NULL,
+	`needId` INT NOT NULL,
+	CONSTRAINT FK_NEED FOREIGN KEY(`needId`) REFERENCES `MedicalNeed`(`id`),
+	PRIMARY KEY(`name`)
+);
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/persist/migrations/20240318060406_migrationLabel/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/persist/migrations/20240318060406_migrationLabel/model.bal
@@ -1,0 +1,27 @@
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+import ballerina/time;
+
+public type MedicalNeed record {|
+    readonly int id;
+    @sql:Char {length: 50}
+    string needDetails;
+    @sql:Varchar {length: 50}
+    string needType;
+    @sql:Decimal {precision: [10,2]}
+    decimal amount;
+    int needId;
+    string itemId;
+    string name;
+    time:Civil period;
+    MedicalItem[] items;
+|};
+
+public type MedicalItem record {|
+    readonly string name;
+    int itemId;
+    string decrip;
+    string unit;
+    int num;
+    MedicalNeed need;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/persist/migrations/20240318060406_migrationLabel/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/persist/migrations/20240318060406_migrationLabel/script.sql
@@ -1,0 +1,13 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE MedicalNeed
+ADD COLUMN needDetails CHAR(50);
+
+ALTER TABLE MedicalNeed
+ADD COLUMN needType VARCHAR(50);
+
+ALTER TABLE MedicalNeed
+ADD COLUMN amount DECIMAL(10,2);
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/persist/model.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/persist as _;
 import ballerinax/persist.sql;
 import ballerina/time;

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_12/persist/model.bal
@@ -1,0 +1,27 @@
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+import ballerina/time;
+
+public type MedicalNeed record {|
+    readonly int id;
+    @sql:Char {length: 50}
+    string needDetails;
+    @sql:Varchar {length: 50}
+    string needType;
+    @sql:Decimal {precision: [10,2]}
+    decimal amount;
+    int needId;
+    string itemId;
+    string name;
+    time:Civil period;
+    MedicalItem[] items;
+|};
+
+public type MedicalItem record {|
+    readonly string name;
+    int itemId;
+    string decrip;
+    string unit;
+    int num;
+    MedicalNeed need;
+|};

--- a/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
@@ -73,6 +73,8 @@ public class Migrate implements BLauncherCmd {
 
     @CommandLine.Parameters
     public List<String> argList;
+    @CommandLine.Option(names = {"--datastore"})
+    private String datastore = "mysql";
 
     public Migrate() {
         this("");
@@ -104,17 +106,8 @@ public class Migrate implements BLauncherCmd {
             return;
         }
 
-        try {
-            HashMap<String, String> ballerinaTomlConfig = TomlSyntaxUtils.readBallerinaTomlConfig(
-                    Paths.get(this.sourcePath, "Ballerina.toml"));
-            String dataStore = ballerinaTomlConfig.get("options.datastore").trim();
-            if (!dataStore.equals(PersistToolsConstants.SupportedDataSources.MYSQL_DB)) {
-                errStream.printf("ERROR: unsupported data store: expected: 'mysql' but found: '%s'%n", dataStore);
-                return;
-            }
-        } catch (BalException e) {
-            errStream.printf("ERROR: failed to locate Ballerina.toml: %s%n",
-                    e.getMessage());
+        if (!Objects.equals(datastore, PersistToolsConstants.SupportedDataSources.MYSQL_DB)) {
+            errStream.println("Error: invalid datastore: " + datastore + ". currently only MySQL is supported.");
             return;
         }
 
@@ -626,7 +619,7 @@ public class Migrate implements BLauncherCmd {
     }
 
     private static void addToMapNoTypeObject(Entity entity, EntityField field, Map<String, List<FieldMetadata>> map) {
-        FieldMetadata fieldMetadata = new FieldMetadata(field.getFieldName());
+        FieldMetadata fieldMetadata = new FieldMetadata(field.getFieldName(), field.getSqlType());
 
         if (!map.containsKey(entity.getEntityName())) {
             List<FieldMetadata> initialData = new ArrayList<>();
@@ -641,7 +634,7 @@ public class Migrate implements BLauncherCmd {
 
     private static void addToMapWithType(Entity entity, EntityField field, Map<String, List<FieldMetadata>> map) {
         FieldMetadata fieldMetadata = new FieldMetadata(field.getFieldName(), field.getFieldType(),
-                field.isArrayType());
+                field.isArrayType(), field.getSqlType());
 
         if (!map.containsKey(entity.getEntityName())) {
             List<FieldMetadata> initialData = new ArrayList<>();
@@ -655,8 +648,10 @@ public class Migrate implements BLauncherCmd {
     }
 
     private static void addToMapNewEntityFK(Entity entity, EntityField field, Map<String, List<FieldMetadata>> map) {
+        EntityField customFk = entity.getFieldByName(field.getRelation().getKeyColumns().get(0).getField());
         FieldMetadata fieldMetadata = new FieldMetadata(field.getRelation().getKeyColumns().get(0).getField(),
-                field.getRelation().getKeyColumns().get(0).getType(), field.isArrayType());
+                    field.getRelation().getKeyColumns().get(0).getType(), field.isArrayType(),
+                    customFk == null ? null : customFk.getSqlType());
 
         if (!map.containsKey(entity.getEntityName())) {
             List<FieldMetadata> initialData = new ArrayList<>();
@@ -682,7 +677,7 @@ public class Migrate implements BLauncherCmd {
                 try {
                     if (!primaryKey.isArrayType()) {
                         pKField = SqlScriptUtils.getTypeNonArray(primaryKey.getDataType(),
-                                PersistToolsConstants.SupportedDataSources.MYSQL_DB);
+                                primaryKey.getSqlType(), PersistToolsConstants.SupportedDataSources.MYSQL_DB);
                     } else {
                         pKField = SqlScriptUtils.getTypeArray(primaryKey.getDataType(),
                                 PersistToolsConstants.SupportedDataSources.MYSQL_DB);
@@ -701,7 +696,7 @@ public class Migrate implements BLauncherCmd {
                     for (FieldMetadata field : addedFields.get(entity)) {
                         try {
                             if (!field.isArrayType()) {
-                                addField = SqlScriptUtils.getTypeNonArray(field.getDataType(),
+                                addField = SqlScriptUtils.getTypeNonArray(field.getDataType(), field.getSqlType(),
                                         PersistToolsConstants.SupportedDataSources.MYSQL_DB);
                             } else {
                                 addField = SqlScriptUtils.getTypeArray(field.getDataType(),
@@ -783,7 +778,7 @@ public class Migrate implements BLauncherCmd {
                             String fieldType = "";
                             try {
                                 if (!field.isArrayType()) {
-                                    fieldType = SqlScriptUtils.getTypeNonArray(field.getDataType(),
+                                    fieldType = SqlScriptUtils.getTypeNonArray(field.getDataType(), field.getSqlType(),
                                             PersistToolsConstants.SupportedDataSources.MYSQL_DB);
                                 } else {
                                     fieldType = SqlScriptUtils.getTypeArray(field.getDataType(),
@@ -809,7 +804,7 @@ public class Migrate implements BLauncherCmd {
                         String fieldType = "";
                         try {
                             if (!field.isArrayType()) {
-                                fieldType = SqlScriptUtils.getTypeNonArray(field.getDataType(),
+                                fieldType = SqlScriptUtils.getTypeNonArray(field.getDataType(), field.getSqlType(),
                                         PersistToolsConstants.SupportedDataSources.MYSQL_DB);
                             } else {
                                 fieldType = SqlScriptUtils.getTypeArray(field.getDataType(),

--- a/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
@@ -28,7 +28,6 @@ import io.ballerina.persist.models.Module;
 import io.ballerina.persist.nodegenerator.SourceGenerator;
 import io.ballerina.persist.nodegenerator.syntax.constants.BalSyntaxConstants;
 import io.ballerina.persist.nodegenerator.syntax.utils.SqlScriptUtils;
-import io.ballerina.persist.nodegenerator.syntax.utils.TomlSyntaxUtils;
 import io.ballerina.persist.utils.BalProjectUtils;
 import picocli.CommandLine;
 

--- a/persist-cli/src/main/java/io/ballerina/persist/models/FieldMetadata.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/models/FieldMetadata.java
@@ -26,15 +26,18 @@ public class FieldMetadata {
     private String name;
     private String dataType;
     private Boolean arrayType;
+    private final SQLType sqlType;
 
-    public FieldMetadata(String name, String dataType, Boolean arrayType) {
+    public FieldMetadata(String name, String dataType, Boolean arrayType, SQLType sqlType) {
         this.name = name;
         this.dataType = dataType;
         this.arrayType = arrayType;
+        this.sqlType = sqlType;
     }
 
-    public FieldMetadata(String name) {
+    public FieldMetadata(String name, SQLType sqlType) {
         this.name = name;
+        this.sqlType = sqlType;
     }
 
     public String getName() {
@@ -59,5 +62,8 @@ public class FieldMetadata {
 
     public void setArrayType(Boolean arrayType) {
         this.arrayType = arrayType;
+    }
+    public SQLType getSqlType() {
+        return sqlType;
     }
 }

--- a/persist-cli/src/main/java/io/ballerina/persist/models/Relation.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/models/Relation.java
@@ -138,7 +138,6 @@ public class Relation {
      */
     public static class Key {
         private final String field;
-
         private final String columnName;
         private final String reference;
         private final String referenceColumnName;

--- a/persist-cli/src/main/java/io/ballerina/persist/nodegenerator/syntax/clients/DbClientSyntax.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/nodegenerator/syntax/clients/DbClientSyntax.java
@@ -43,6 +43,7 @@ import io.ballerina.persist.nodegenerator.syntax.constants.SyntaxTokenConstants;
 import io.ballerina.persist.nodegenerator.syntax.utils.BalSyntaxUtils;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This class is used to generate the DB client syntax tree.
@@ -295,24 +296,46 @@ public class DbClientSyntax implements ClientSyntax {
                             if (associateFieldMetaData.length() != 0) {
                                 associateFieldMetaData.append(BalSyntaxConstants.COMMA_WITH_NEWLINE);
                             }
-                            associateFieldMetaData.append(String.format((field.isArrayType() ? "\"%s[]" : "\"%s") +
-                                            BalSyntaxConstants.ASSOCIATED_FIELD_TEMPLATE,
-                                    BalSyntaxUtils.stripEscapeCharacter(field.getFieldName()),
-                                    BalSyntaxUtils.stripEscapeCharacter(associatedEntityField.getFieldName()),
-                                    BalSyntaxUtils.stripEscapeCharacter(field.getFieldName()),
-                                    BalSyntaxUtils.stripEscapeCharacter(associatedEntityField.getFieldName())));
+                            if (Objects.equals(associatedEntityField.getFieldName(),
+                                    associatedEntityField.getFieldColumnName())) {
+                                associateFieldMetaData.append(String.format((field.isArrayType() ? "\"%s[]" : "\"%s") +
+                                                BalSyntaxConstants.ASSOCIATED_FIELD_TEMPLATE,
+                                        BalSyntaxUtils.stripEscapeCharacter(field.getFieldName()),
+                                        BalSyntaxUtils.stripEscapeCharacter(associatedEntityField.getFieldName()),
+                                        BalSyntaxUtils.stripEscapeCharacter(field.getFieldName()),
+                                        BalSyntaxUtils.stripEscapeCharacter(associatedEntityField.getFieldName())));
+                            } else {
+                                associateFieldMetaData.append(String.format((field.isArrayType() ? "\"%s[]" : "\"%s") +
+                                                BalSyntaxConstants.ASSOCIATED_FIELD_TEMPLATE_MAPPED,
+                                        BalSyntaxUtils.stripEscapeCharacter(field.getFieldName()),
+                                        BalSyntaxUtils.stripEscapeCharacter(associatedEntityField.getFieldName()),
+                                        BalSyntaxUtils.stripEscapeCharacter(field.getFieldName()),
+                                        BalSyntaxUtils.stripEscapeCharacter(associatedEntityField.getFieldName()),
+                                        BalSyntaxUtils.stripEscapeCharacter(associatedEntityField.getFieldColumnName())
+                                ));
+                            }
                         } else {
                             if (associatedEntityField.getRelation().isOwner()) {
                                     for (Relation.Key key : associatedEntityField.getRelation().getKeyColumns()) {
                                         if (associateFieldMetaData.length() != 0) {
                                             associateFieldMetaData.append(BalSyntaxConstants.COMMA_WITH_NEWLINE);
                                         }
-                                        associateFieldMetaData.append(String.format((field.isArrayType() ?
-                                                        "\"%s[]" : "\"%s") +
-                                                        BalSyntaxConstants.ASSOCIATED_FIELD_TEMPLATE,
-                                                field.getFieldName(), key.getField(),
-                                                BalSyntaxUtils.stripEscapeCharacter(field.getFieldName()),
-                                                BalSyntaxUtils.stripEscapeCharacter(key.getField())));
+                                        if (Objects.equals(key.getField(), key.getColumnName())) {
+                                            associateFieldMetaData.append(String.format((field.isArrayType() ?
+                                                            "\"%s[]" : "\"%s") +
+                                                            BalSyntaxConstants.ASSOCIATED_FIELD_TEMPLATE,
+                                                    field.getFieldName(), key.getField(),
+                                                    BalSyntaxUtils.stripEscapeCharacter(field.getFieldName()),
+                                                    BalSyntaxUtils.stripEscapeCharacter(key.getField())));
+                                        } else {
+                                            associateFieldMetaData.append(String.format((field.isArrayType() ?
+                                                            "\"%s[]" : "\"%s") +
+                                                            BalSyntaxConstants.ASSOCIATED_FIELD_TEMPLATE_MAPPED,
+                                                    field.getFieldName(), key.getField(),
+                                                    BalSyntaxUtils.stripEscapeCharacter(field.getFieldName()),
+                                                    BalSyntaxUtils.stripEscapeCharacter(key.getField()),
+                                                    BalSyntaxUtils.stripEscapeCharacter(key.getColumnName())));
+                                        }
                                     }
                             }
                         }
@@ -321,8 +344,15 @@ public class DbClientSyntax implements ClientSyntax {
                     if (fieldMetaData.length() != 0) {
                         fieldMetaData.append(BalSyntaxConstants.COMMA_WITH_NEWLINE);
                     }
-                    fieldMetaData.append(String.format(BalSyntaxConstants.METADATA_RECORD_FIELD_TEMPLATE,
-                            field.getFieldName(), BalSyntaxUtils.stripEscapeCharacter(field.getFieldColumnName())));
+                    if (field.isDbGenerated()) {
+                        fieldMetaData.append(String.format(BalSyntaxConstants.METADATA_RECORD_FIELD_WITH_DBGEN_TEMPLATE,
+                                field.getFieldName(), BalSyntaxUtils.stripEscapeCharacter(field.getFieldColumnName()),
+                                "true"));
+                    } else {
+                        fieldMetaData.append(String.format(BalSyntaxConstants.METADATA_RECORD_FIELD_TEMPLATE,
+                                field.getFieldName(), BalSyntaxUtils.stripEscapeCharacter(field.getFieldColumnName())));
+                    }
+
                 }
             }
             if (associateFieldMetaData.length() > 1) {

--- a/persist-cli/src/main/java/io/ballerina/persist/nodegenerator/syntax/constants/BalSyntaxConstants.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/nodegenerator/syntax/constants/BalSyntaxConstants.java
@@ -190,6 +190,7 @@ public class BalSyntaxConstants {
     public static final String TABLE_NAME_TEMPLATE = "tableName: \"%s\", " + System.lineSeparator();
     public static final String METADATA_RECORD_TABLE_NAME_TEMPLATE = "tableName: \"%s\", " + System.lineSeparator();
     public static final String METADATA_RECORD_FIELD_TEMPLATE = "%s: {columnName: \"%s\"}";
+    public static final String METADATA_RECORD_FIELD_WITH_DBGEN_TEMPLATE = "%s: {columnName: \"%s\", dbGenerated: %s}";
     public static final String METADATA_KEY_FIELDS_TEMPLATE = "keyFields: [%s], " + System.lineSeparator();
     public static final String G_SHEET_FIELD_METADATA_TEMPLATE = "%s: {columnName: \"%s\", columnId: \"%s\"}";
     public static final String FIELD_TYPE = "%s: \"%s\"";
@@ -253,6 +254,8 @@ public class BalSyntaxConstants {
     public static final String CONDITION_STATEMENT = "'object.%s == value[\"%s\"] ";
     public static final String VARIABLE = "\"%s\": %s,";
     public static final String ASSOCIATED_FIELD_TEMPLATE = ".%s\": {relation: {entityName: \"%s\", refField: \"%s\"}}";
+    public static final String ASSOCIATED_FIELD_TEMPLATE_MAPPED =
+            ".%s\": {relation: {entityName: \"%s\", refField: \"%s\", refColumn: \"%s\"}}";
     public static final String CONSTRAINT_ANNOTATION = "@constraint:String {" + System.lineSeparator() +
             "        %s" + System.lineSeparator() +
             "    }";

--- a/persist-cli/src/main/java/io/ballerina/persist/nodegenerator/syntax/utils/SqlScriptUtils.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/nodegenerator/syntax/utils/SqlScriptUtils.java
@@ -153,9 +153,24 @@ public class SqlScriptUtils {
                 columnScript.append(MessageFormat.format("{0}{1}{2} {3},",
                         NEW_LINE, TAB, fieldName, sqlType));
             } else {
-                columnScript.append(MessageFormat.format("{0}{1}{2} {3}{4},",
-                        NEW_LINE, TAB, fieldName, sqlType,
-                        entityField.isDbGenerated() ? " AUTO_INCREMENT" : " NOT NULL"));
+                switch (datasource) {
+                    case (PersistToolsConstants.SupportedDataSources.MSSQL_DB):
+                        columnScript.append(MessageFormat.format("{0}{1}{2} {3}{4},",
+                                NEW_LINE, TAB, fieldName, sqlType,
+                                entityField.isDbGenerated() ? " IDENTITY(1,1)" : " NOT NULL"));
+                        break;
+                    case (PersistToolsConstants.SupportedDataSources.POSTGRESQL_DB):
+                        columnScript.append(MessageFormat.format("{0}{1}{2} {3}{4},",
+                                NEW_LINE, TAB, fieldName, "",
+                                entityField.isDbGenerated() ? " SERIAL" : sqlType + " NOT NULL"));
+                        break;
+                    case (PersistToolsConstants.SupportedDataSources.MYSQL_DB):
+                        columnScript.append(MessageFormat.format("{0}{1}{2} {3}{4},",
+                                NEW_LINE, TAB, fieldName, sqlType,
+                                entityField.isDbGenerated() ? " AUTO_INCREMENT" : " NOT NULL"));
+                        break;
+                    default: { }
+                }
             }
         }
         return columnScript.toString();

--- a/persist-cli/src/main/resources/cli-help/ballerina-persist.help
+++ b/persist-cli/src/main/resources/cli-help/ballerina-persist.help
@@ -62,5 +62,8 @@ BALLERINA COMMANDS
                        the `bal build` command.
        init            Initialize the package for persistence and create the "persist" directory and data model file.
        generate        Generate the client API based on the data model defined in the "persist" directory
+       migrate         Migrate the database schema to the latest version by checking the current model file and the
+                       previous.
+       pull            Introspect the database to generate the data model file.
 
 Use 'bal persist <command> --help' for more information on a specific command.

--- a/persist-cli/src/main/resources/cli-help/ballerina-persist.help
+++ b/persist-cli/src/main/resources/cli-help/ballerina-persist.help
@@ -62,8 +62,7 @@ BALLERINA COMMANDS
                        the `bal build` command.
        init            Initialize the package for persistence and create the "persist" directory and data model file.
        generate        Generate the client API based on the data model defined in the "persist" directory
-       migrate         Migrate the database schema to the latest version by checking the current model file and the
-                       previous.
-       pull            Introspect the database to generate the data model file.
+       migrate         Generate the database migration scripts to the latest version by scanning model file changes
+       pull            Introspect an SQL database to generate the data model file
 
 Use 'bal persist <command> --help' for more information on a specific command.


### PR DESCRIPTION
## Purpose
Implements tooling support for the updated changes in the `persist.sql` from the [PR61](https://github.com/ballerina-platform/module-ballerinax-persist.sql/pull/61).

Fixes:
- Tooling change to support new `persist.sql` client API
- Add test cases to test annotations on MSSQL and PostgreSQL databases
## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [X] Added tests
