### PR TITLE
Add migration support for `sql:Index` and `sql:UniqueIndex` annotations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Added introspection support for MySQL databases](https://github.com/ballerina-platform/ballerina-library/issues/6014)
 - [Added advanced annotation support for SQL databases](https://github.com/ballerina-platform/ballerina-library/issues/6013)
 - [Added support for name, type, generated and relation annotations in migrate command](https://github.com/ballerina-platform/ballerina-library/issues/6189)
+- [Added support for index and unique index annotations in migrate command](https://github.com/ballerina-platform/ballerina-library/issues/6189)
 
 ## [1.2.1] - 2021-11-21
 

--- a/persist-cli-tests/src/test/java/io/ballerina/persist/tools/ToolingMigrateTest.java
+++ b/persist-cli-tests/src/test/java/io/ballerina/persist/tools/ToolingMigrateTest.java
@@ -320,6 +320,41 @@ public class ToolingMigrateTest {
         assertMigrateGeneratedSources("tool_test_migrate_40");
     }
 
+    @Test(enabled = true)
+    @Description("Test add new index columns")
+    public void testMigrateAddNewIndexColumns() {
+        executeCommand("tool_test_migrate_41", "secondMigration");
+        assertMigrateGeneratedSources("tool_test_migrate_41");
+    }
+
+    @Test(enabled = true)
+    @Description("Test modify and remove index columns")
+    public void testMigrateModifyAndRemoveIndexColumns() {
+        executeCommand("tool_test_migrate_42", "secondMigration");
+        assertMigrateGeneratedSources("tool_test_migrate_42");
+    }
+
+    @Test(enabled = true)
+    @Description("Test add new unique index columns")
+    public void testMigrateAddNewUniqueIndexColumns() {
+        executeCommand("tool_test_migrate_43", "secondMigration");
+        assertMigrateGeneratedSources("tool_test_migrate_43");
+    }
+
+    @Test(enabled = true)
+    @Description("Test modify and remove unique index columns")
+    public void testMigrateModifyAndRemoveUniqueIndexColumns() {
+        executeCommand("tool_test_migrate_44", "secondMigration");
+        assertMigrateGeneratedSources("tool_test_migrate_44");
+    }
+
+    @Test(enabled = true)
+    @Description("Test add table with index columns")
+    public void testMigrateAddTableWithIndexColumns() {
+        executeCommand("tool_test_migrate_45", "secondMigration");
+        assertMigrateGeneratedSources("tool_test_migrate_45");
+    }
+
     private void executeCommand(String subDir, String migrationLabel) {
         Class<?> persistClass;
         Path sourcePath = Paths.get(GENERATED_SOURCES_DIRECTORY, subDir);

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_41/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_41/Ballerina.toml
@@ -1,0 +1,19 @@
+[package]
+org = "wso2"
+name = "migrate_test"
+version = "0.1.0"
+distribution = "2201.5.0"
+
+[build-options]
+observabilityIncluded = true
+
+[[tool.persist]]
+id = "persist"
+options.datastore = "mysql"
+targetModule = "migrate_test"
+filePath = "persist/model.bal"
+
+[[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "persist.sql-native"
+version = "1.3.0-SNAPSHOT"

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_41/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_41/main.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_41/persist/migrations/20240404031240_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_41/persist/migrations/20240404031240_firstMigration/model.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+
+public type Person record {|
+    readonly int id;
+    string name;
+    int age;
+    string field1;
+    string field2;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_41/persist/migrations/20240404031240_firstMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_41/persist/migrations/20240404031240_firstMigration/script.sql
@@ -1,0 +1,7 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+MODIFY COLUMN id INT NOT NULL;
+

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_41/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_41/persist/model.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    @sql:Index {name: "name_idx"}
+    string name;
+    @sql:Index
+    int age;
+    @sql:Index {name: "fields_idx"}
+    string field1;
+    @sql:Index {name: "fields_idx"}
+    string field2;
+    @sql:Name {value: "new_field"}
+    @sql:Index {name: "new_field_idx"}
+    string newField;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_42/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_42/Ballerina.toml
@@ -1,0 +1,19 @@
+[package]
+org = "wso2"
+name = "migrate_test"
+version = "0.1.0"
+distribution = "2201.5.0"
+
+[build-options]
+observabilityIncluded = true
+
+[[tool.persist]]
+id = "persist"
+options.datastore = "mysql"
+targetModule = "migrate_test"
+filePath = "persist/model.bal"
+
+[[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "persist.sql-native"
+version = "1.3.0-SNAPSHOT"

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_42/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_42/main.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_42/persist/migrations/20240409054629_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_42/persist/migrations/20240409054629_firstMigration/model.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    @sql:Index {name: "name_idx"}
+    string name;
+    @sql:Index
+    int age;
+    @sql:Index {name: ["address_idx", "another_idx"]}
+    string address;
+    @sql:Index {name: "fields_idx"}
+    string field1;
+    @sql:Index {name: "fields_idx"}
+    string field2;
+    @sql:Index {name: "new_field_idx"}
+    string field3;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_42/persist/migrations/20240409054629_firstMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_42/persist/migrations/20240409054629_firstMigration/script.sql
@@ -1,0 +1,15 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+ADD COLUMN new_field VARCHAR(191) NOT NULL;
+
+CREATE INDEX name_idx ON Person(name);
+
+CREATE INDEX idx_age ON Person(age);
+
+CREATE INDEX fields_idx ON Person(field1, field2);
+
+CREATE INDEX new_field_idx ON Person(new_field);
+

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_42/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_42/persist/model.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    string name;
+    int age;
+    @sql:Index {name: ["another_idx"]}
+    string address;
+    @sql:Index {name: ["fields_idx", "field1_index"]}
+    string field1;
+    @sql:Index {name: "fields_idx"}
+    string field2;
+    @sql:Index {name: "new_field_idx"}
+    string field3;
+    @sql:Index {name: "new_field_idx"}
+    string field4;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_43/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_43/Ballerina.toml
@@ -1,0 +1,19 @@
+[package]
+org = "wso2"
+name = "migrate_test"
+version = "0.1.0"
+distribution = "2201.5.0"
+
+[build-options]
+observabilityIncluded = true
+
+[[tool.persist]]
+id = "persist"
+options.datastore = "mysql"
+targetModule = "migrate_test"
+filePath = "persist/model.bal"
+
+[[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "persist.sql-native"
+version = "1.3.0-SNAPSHOT"

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_43/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_43/main.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_43/persist/migrations/20240404031240_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_43/persist/migrations/20240404031240_firstMigration/model.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+
+public type Person record {|
+    readonly int id;
+    string name;
+    int age;
+    string field1;
+    string field2;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_43/persist/migrations/20240404031240_firstMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_43/persist/migrations/20240404031240_firstMigration/script.sql
@@ -1,0 +1,7 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+MODIFY COLUMN id INT NOT NULL;
+

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_43/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_43/persist/model.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    @sql:UniqueIndex {name: "name_idx"}
+    string name;
+    @sql:UniqueIndex
+    int age;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field1;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field2;
+    @sql:Name {value: "new_field"}
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string newField;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_44/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_44/Ballerina.toml
@@ -1,0 +1,19 @@
+[package]
+org = "wso2"
+name = "migrate_test"
+version = "0.1.0"
+distribution = "2201.5.0"
+
+[build-options]
+observabilityIncluded = true
+
+[[tool.persist]]
+id = "persist"
+options.datastore = "mysql"
+targetModule = "migrate_test"
+filePath = "persist/model.bal"
+
+[[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "persist.sql-native"
+version = "1.3.0-SNAPSHOT"

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_44/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_44/main.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_44/persist/migrations/20240409054629_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_44/persist/migrations/20240409054629_firstMigration/model.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    @sql:UniqueIndex {name: "name_idx"}
+    string name;
+    @sql:UniqueIndex
+    int age;
+    @sql:UniqueIndex {name: ["address_idx", "another_idx"]}
+    string address;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field1;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field2;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field3;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_44/persist/migrations/20240409054629_firstMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_44/persist/migrations/20240409054629_firstMigration/script.sql
@@ -1,0 +1,15 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+ADD COLUMN new_field VARCHAR(191) NOT NULL;
+
+CREATE UNIQUE INDEX name_idx ON Person(name);
+
+CREATE UNIQUE INDEX idx_age ON Person(age);
+
+CREATE UNIQUE INDEX fields_idx ON Person(field1, field2);
+
+CREATE UNIQUE INDEX new_field_idx ON Person(new_field);
+

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_44/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_44/persist/model.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    string name;
+    int age;
+    @sql:UniqueIndex {name: ["another_idx"]}
+    string address;
+    @sql:UniqueIndex {name: ["fields_idx", "field1_index"]}
+    string field1;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field2;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field3;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field4;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_45/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_45/Ballerina.toml
@@ -1,0 +1,19 @@
+[package]
+org = "wso2"
+name = "migrate_test"
+version = "0.1.0"
+distribution = "2201.5.0"
+
+[build-options]
+observabilityIncluded = true
+
+[[tool.persist]]
+id = "persist"
+options.datastore = "mysql"
+targetModule = "migrate_test"
+filePath = "persist/model.bal"
+
+[[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "persist.sql-native"
+version = "1.3.0-SNAPSHOT"

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_45/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_45/main.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_45/persist/migrations/20240409054629_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_45/persist/migrations/20240409054629_firstMigration/model.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    @sql:UniqueIndex {name: "name_idx"}
+    string name;
+    @sql:UniqueIndex
+    int age;
+    @sql:UniqueIndex {name: ["address_idx", "another_idx"]}
+    string address;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field1;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field2;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field3;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_45/persist/migrations/20240409054629_firstMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_45/persist/migrations/20240409054629_firstMigration/script.sql
@@ -1,0 +1,15 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+ADD COLUMN new_field VARCHAR(191) NOT NULL;
+
+CREATE UNIQUE INDEX name_idx ON Person(name);
+
+CREATE UNIQUE INDEX idx_age ON Person(age);
+
+CREATE UNIQUE INDEX fields_idx ON Person(field1, field2);
+
+CREATE UNIQUE INDEX new_field_idx ON Person(new_field);
+

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_45/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_45/persist/model.bal
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    string name;
+    int age;
+    @sql:UniqueIndex {name: ["another_idx"]}
+    string address;
+    @sql:UniqueIndex {name: ["fields_idx", "field1_index"]}
+    string field1;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field2;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field3;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field4;
+|};
+
+public type Car record {|
+    readonly int id;
+    @sql:UniqueIndex {name: "car_name_idx"}
+    string name;
+    @sql:Index {name: "car_model_idx"}
+    string model;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/Ballerina.toml
@@ -1,0 +1,19 @@
+[package]
+org = "wso2"
+name = "migrate_test"
+version = "0.1.0"
+distribution = "2201.5.0"
+
+[build-options]
+observabilityIncluded = true
+
+[[tool.persist]]
+id = "persist"
+options.datastore = "mysql"
+targetModule = "migrate_test"
+filePath = "persist/model.bal"
+
+[[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "persist.sql-native"
+version = "1.3.0-SNAPSHOT"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/main.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/persist/migrations/20240404031240_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/persist/migrations/20240404031240_firstMigration/model.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+
+public type Person record {|
+    readonly int id;
+    string name;
+    int age;
+    string field1;
+    string field2;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/persist/migrations/20240404031240_firstMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/persist/migrations/20240404031240_firstMigration/script.sql
@@ -1,0 +1,7 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+MODIFY COLUMN id INT NOT NULL;
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/persist/migrations/20240409054629_secondMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/persist/migrations/20240409054629_secondMigration/model.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    @sql:Index {name: "name_idx"}
+    string name;
+    @sql:Index
+    int age;
+    @sql:Index {name: "fields_idx"}
+    string field1;
+    @sql:Index {name: "fields_idx"}
+    string field2;
+    @sql:Name {value: "new_field"}
+    @sql:Index {name: "new_field_idx"}
+    string newField;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/persist/migrations/20240409054629_secondMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/persist/migrations/20240409054629_secondMigration/script.sql
@@ -1,0 +1,15 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+ADD COLUMN new_field VARCHAR(191) NOT NULL;
+
+CREATE INDEX name_idx ON Person(name);
+
+CREATE INDEX idx_age ON Person(age);
+
+CREATE INDEX fields_idx ON Person(field1, field2);
+
+CREATE INDEX new_field_idx ON Person(new_field);
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_41/persist/model.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    @sql:Index {name: "name_idx"}
+    string name;
+    @sql:Index
+    int age;
+    @sql:Index {name: "fields_idx"}
+    string field1;
+    @sql:Index {name: "fields_idx"}
+    string field2;
+    @sql:Name {value: "new_field"}
+    @sql:Index {name: "new_field_idx"}
+    string newField;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/Ballerina.toml
@@ -1,0 +1,19 @@
+[package]
+org = "wso2"
+name = "migrate_test"
+version = "0.1.0"
+distribution = "2201.5.0"
+
+[build-options]
+observabilityIncluded = true
+
+[[tool.persist]]
+id = "persist"
+options.datastore = "mysql"
+targetModule = "migrate_test"
+filePath = "persist/model.bal"
+
+[[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "persist.sql-native"
+version = "1.3.0-SNAPSHOT"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/main.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/persist/migrations/20240409054629_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/persist/migrations/20240409054629_firstMigration/model.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    @sql:Index {name: "name_idx"}
+    string name;
+    @sql:Index
+    int age;
+    @sql:Index {name: ["address_idx", "another_idx"]}
+    string address;
+    @sql:Index {name: "fields_idx"}
+    string field1;
+    @sql:Index {name: "fields_idx"}
+    string field2;
+    @sql:Index {name: "new_field_idx"}
+    string field3;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/persist/migrations/20240409054629_firstMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/persist/migrations/20240409054629_firstMigration/script.sql
@@ -1,0 +1,15 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+ADD COLUMN new_field VARCHAR(191) NOT NULL;
+
+CREATE INDEX name_idx ON Person(name);
+
+CREATE INDEX idx_age ON Person(age);
+
+CREATE INDEX fields_idx ON Person(field1, field2);
+
+CREATE INDEX new_field_idx ON Person(new_field);
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/persist/migrations/20240409073625_secondMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/persist/migrations/20240409073625_secondMigration/model.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    string name;
+    int age;
+    @sql:Index {name: ["another_idx"]}
+    string address;
+    @sql:Index {name: ["fields_idx", "field1_index"]}
+    string field1;
+    @sql:Index {name: "fields_idx"}
+    string field2;
+    @sql:Index {name: "new_field_idx"}
+    string field3;
+    @sql:Index {name: "new_field_idx"}
+    string field4;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/persist/migrations/20240409073625_secondMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/persist/migrations/20240409073625_secondMigration/script.sql
@@ -1,0 +1,19 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+ADD COLUMN field4 VARCHAR(191) NOT NULL;
+
+DROP INDEX name_idx ON Person;
+
+DROP INDEX idx_age ON Person;
+
+DROP INDEX address_idx ON Person;
+
+DROP INDEX new_field_idx ON Person;
+
+CREATE INDEX new_field_idx ON Person(field3, field4);
+
+CREATE INDEX field1_index ON Person(field1);
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_42/persist/model.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    string name;
+    int age;
+    @sql:Index {name: ["another_idx"]}
+    string address;
+    @sql:Index {name: ["fields_idx", "field1_index"]}
+    string field1;
+    @sql:Index {name: "fields_idx"}
+    string field2;
+    @sql:Index {name: "new_field_idx"}
+    string field3;
+    @sql:Index {name: "new_field_idx"}
+    string field4;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/Ballerina.toml
@@ -1,0 +1,19 @@
+[package]
+org = "wso2"
+name = "migrate_test"
+version = "0.1.0"
+distribution = "2201.5.0"
+
+[build-options]
+observabilityIncluded = true
+
+[[tool.persist]]
+id = "persist"
+options.datastore = "mysql"
+targetModule = "migrate_test"
+filePath = "persist/model.bal"
+
+[[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "persist.sql-native"
+version = "1.3.0-SNAPSHOT"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/main.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/persist/migrations/20240404031240_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/persist/migrations/20240404031240_firstMigration/model.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+
+public type Person record {|
+    readonly int id;
+    string name;
+    int age;
+    string field1;
+    string field2;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/persist/migrations/20240404031240_firstMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/persist/migrations/20240404031240_firstMigration/script.sql
@@ -1,0 +1,7 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+MODIFY COLUMN id INT NOT NULL;
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/persist/migrations/20240409084408_secondMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/persist/migrations/20240409084408_secondMigration/model.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    @sql:UniqueIndex {name: "name_idx"}
+    string name;
+    @sql:UniqueIndex
+    int age;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field1;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field2;
+    @sql:Name {value: "new_field"}
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string newField;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/persist/migrations/20240409084408_secondMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/persist/migrations/20240409084408_secondMigration/script.sql
@@ -1,0 +1,15 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+ADD COLUMN new_field VARCHAR(191) NOT NULL;
+
+CREATE UNIQUE INDEX name_idx ON Person(name);
+
+CREATE UNIQUE INDEX unique_idx_age ON Person(age);
+
+CREATE UNIQUE INDEX fields_idx ON Person(field1, field2);
+
+CREATE UNIQUE INDEX new_field_idx ON Person(new_field);
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_43/persist/model.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    @sql:UniqueIndex {name: "name_idx"}
+    string name;
+    @sql:UniqueIndex
+    int age;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field1;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field2;
+    @sql:Name {value: "new_field"}
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string newField;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/Ballerina.toml
@@ -1,0 +1,19 @@
+[package]
+org = "wso2"
+name = "migrate_test"
+version = "0.1.0"
+distribution = "2201.5.0"
+
+[build-options]
+observabilityIncluded = true
+
+[[tool.persist]]
+id = "persist"
+options.datastore = "mysql"
+targetModule = "migrate_test"
+filePath = "persist/model.bal"
+
+[[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "persist.sql-native"
+version = "1.3.0-SNAPSHOT"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/main.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/persist/migrations/20240409054629_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/persist/migrations/20240409054629_firstMigration/model.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    @sql:UniqueIndex {name: "name_idx"}
+    string name;
+    @sql:UniqueIndex
+    int age;
+    @sql:UniqueIndex {name: ["address_idx", "another_idx"]}
+    string address;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field1;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field2;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field3;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/persist/migrations/20240409054629_firstMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/persist/migrations/20240409054629_firstMigration/script.sql
@@ -1,0 +1,15 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+ADD COLUMN new_field VARCHAR(191) NOT NULL;
+
+CREATE UNIQUE INDEX name_idx ON Person(name);
+
+CREATE UNIQUE INDEX idx_age ON Person(age);
+
+CREATE UNIQUE INDEX fields_idx ON Person(field1, field2);
+
+CREATE UNIQUE INDEX new_field_idx ON Person(new_field);
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/persist/migrations/20240409085238_secondMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/persist/migrations/20240409085238_secondMigration/model.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    string name;
+    int age;
+    @sql:UniqueIndex {name: ["another_idx"]}
+    string address;
+    @sql:UniqueIndex {name: ["fields_idx", "field1_index"]}
+    string field1;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field2;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field3;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field4;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/persist/migrations/20240409085238_secondMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/persist/migrations/20240409085238_secondMigration/script.sql
@@ -1,0 +1,19 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+ADD COLUMN field4 VARCHAR(191) NOT NULL;
+
+DROP INDEX name_idx ON Person;
+
+DROP INDEX unique_idx_age ON Person;
+
+DROP INDEX address_idx ON Person;
+
+DROP INDEX new_field_idx ON Person;
+
+CREATE UNIQUE INDEX new_field_idx ON Person(field3, field4);
+
+CREATE UNIQUE INDEX field1_index ON Person(field1);
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_44/persist/model.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    string name;
+    int age;
+    @sql:UniqueIndex {name: ["another_idx"]}
+    string address;
+    @sql:UniqueIndex {name: ["fields_idx", "field1_index"]}
+    string field1;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field2;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field3;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field4;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/Ballerina.toml
@@ -1,0 +1,19 @@
+[package]
+org = "wso2"
+name = "migrate_test"
+version = "0.1.0"
+distribution = "2201.5.0"
+
+[build-options]
+observabilityIncluded = true
+
+[[tool.persist]]
+id = "persist"
+options.datastore = "mysql"
+targetModule = "migrate_test"
+filePath = "persist/model.bal"
+
+[[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "persist.sql-native"
+version = "1.3.0-SNAPSHOT"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/main.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/main.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/persist/migrations/20240409054629_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/persist/migrations/20240409054629_firstMigration/model.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    @sql:UniqueIndex {name: "name_idx"}
+    string name;
+    @sql:UniqueIndex
+    int age;
+    @sql:UniqueIndex {name: ["address_idx", "another_idx"]}
+    string address;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field1;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field2;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field3;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/persist/migrations/20240409054629_firstMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/persist/migrations/20240409054629_firstMigration/script.sql
@@ -1,0 +1,15 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+ALTER TABLE Person
+ADD COLUMN new_field VARCHAR(191) NOT NULL;
+
+CREATE UNIQUE INDEX name_idx ON Person(name);
+
+CREATE UNIQUE INDEX idx_age ON Person(age);
+
+CREATE UNIQUE INDEX fields_idx ON Person(field1, field2);
+
+CREATE UNIQUE INDEX new_field_idx ON Person(new_field);
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/persist/migrations/20240409093039_secondMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/persist/migrations/20240409093039_secondMigration/model.bal
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    string name;
+    int age;
+    @sql:UniqueIndex {name: ["another_idx"]}
+    string address;
+    @sql:UniqueIndex {name: ["fields_idx", "field1_index"]}
+    string field1;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field2;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field3;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field4;
+|};
+
+public type Car record {|
+    readonly int id;
+    @sql:UniqueIndex {name: "car_name_idx"}
+    string name;
+    @sql:Index {name: "car_model_idx"}
+    string model;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/persist/migrations/20240409093039_secondMigration/script.sql
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/persist/migrations/20240409093039_secondMigration/script.sql
@@ -1,0 +1,31 @@
+-- AUTO-GENERATED FILE.
+-- This file is an auto-generated file by Ballerina persistence layer for the migrate command.
+-- Please verify the generated scripts and execute them against the target DB server.
+
+
+CREATE TABLE `Car` (
+	`id` INT NOT NULL,
+	`name` VARCHAR(191) NOT NULL,
+	`model` VARCHAR(191) NOT NULL,
+	PRIMARY KEY(`id`)
+);
+
+ALTER TABLE Person
+ADD COLUMN field4 VARCHAR(191) NOT NULL;
+
+DROP INDEX name_idx ON Person;
+
+DROP INDEX unique_idx_age ON Person;
+
+DROP INDEX address_idx ON Person;
+
+DROP INDEX new_field_idx ON Person;
+
+CREATE INDEX car_model_idx ON Car(model);
+
+CREATE UNIQUE INDEX car_name_idx ON Car(name);
+
+CREATE UNIQUE INDEX new_field_idx ON Person(field3, field4);
+
+CREATE UNIQUE INDEX field1_index ON Person(field1);
+

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_45/persist/model.bal
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/persist as _;
+import ballerinax/persist.sql;
+
+public type Person record {|
+    readonly int id;
+    string name;
+    int age;
+    @sql:UniqueIndex {name: ["another_idx"]}
+    string address;
+    @sql:UniqueIndex {name: ["fields_idx", "field1_index"]}
+    string field1;
+    @sql:UniqueIndex {name: "fields_idx"}
+    string field2;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field3;
+    @sql:UniqueIndex {name: "new_field_idx"}
+    string field4;
+|};
+
+public type Car record {|
+    readonly int id;
+    @sql:UniqueIndex {name: "car_name_idx"}
+    string name;
+    @sql:Index {name: "car_model_idx"}
+    string model;
+|};

--- a/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
@@ -652,7 +652,7 @@ public class Migrate implements BLauncherCmd {
         return indexMap;
     }
 
-    private static void addRenameFieldQueries(HashMap<String, List<MigrationDataHolder.NameMapping>> renamedFields,
+    private static void addRenameFieldQueries(Map<String, List<MigrationDataHolder.NameMapping>> renamedFields,
                                               List<String> queries) {
         String renameFieldTemplate = "ALTER TABLE %s%nRENAME COLUMN %s TO %s;%n";
         for (Map.Entry<String, List<MigrationDataHolder.NameMapping>> entry : renamedFields.entrySet()) {

--- a/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
@@ -700,7 +700,7 @@ public class Migrate implements BLauncherCmd {
 
     private static void addCreateTableQueries(List<String> addedEntities, Module currentModel,
                                               List<String> queries) {
-        for (String tableName:addedEntities) {
+        for (String tableName : addedEntities) {
             Optional<Entity> entity = currentModel.getEntityByTableName(tableName);
             if (entity.isPresent()) {
                 try {

--- a/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
@@ -553,7 +553,6 @@ public class Migrate implements BLauncherCmd {
         return true;
     }
 
-
     private static void printDetailedListOfDifferences(List<String> differences) {
         errStream.println(System.lineSeparator() + "Detailed list of differences: ");
         if (!differences.isEmpty()) {
@@ -610,7 +609,6 @@ public class Migrate implements BLauncherCmd {
         });
     }
 
-    // Convert Create Table List to Query
     private static void addCreateTableQueries(List<String> addedEntities, Module currentModel,
                                               List<String> queries) {
         for (String tableName:addedEntities) {
@@ -626,7 +624,6 @@ public class Migrate implements BLauncherCmd {
         }
     }
 
-    // Convert list to a MySQL query
     private static void addDropTableQueries(List<String> entities, List<String> queries) {
         for (String entity : entities) {
             String removeTableTemplate = "DROP TABLE %s;%n";
@@ -659,7 +656,6 @@ public class Migrate implements BLauncherCmd {
         }
     }
 
-    // Convert map of FieldMetadata lists to a MySQL query
     private static void addModifyColumnTypeQueries(Map<String, List<EntityField>> map, List<String> queries) {
         for (Map.Entry<String, List<EntityField>> entry : map.entrySet()) {
             String entity = entry.getKey();
@@ -704,7 +700,6 @@ public class Migrate implements BLauncherCmd {
         }
     }
 
-    // Convert map of ForeignKey lists to a MySQL query
     private static void addCreateForeignKeyQueries(Map<String, List<ForeignKey>> map, List<String> queries) {
         String addFKTemplate = "ALTER TABLE %s%nADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s(%s);%n";
         for (Map.Entry<String, List<ForeignKey>> entry : map.entrySet()) {

--- a/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
@@ -23,6 +23,7 @@ import io.ballerina.persist.PersistToolsConstants;
 import io.ballerina.persist.models.Entity;
 import io.ballerina.persist.models.EntityField;
 import io.ballerina.persist.models.ForeignKey;
+import io.ballerina.persist.models.Index;
 import io.ballerina.persist.models.MigrationDataHolder;
 import io.ballerina.persist.models.Module;
 import io.ballerina.persist.models.Relation;
@@ -521,6 +522,15 @@ public class Migrate implements BLauncherCmd {
             }
         }
 
+        // Check for index changes
+        HashMap<String, List<Index>> previousIndexes = getIndexesFromModule(previousModel);
+        HashMap<String, List<Index>> currentIndexes = getIndexesFromModule(currentModel);
+        processIndexDifferences(previousIndexes, currentIndexes, migrationDataHolder);
+
+        HashMap<String, List<Index>> previousUniqueIndexes = getUniqueIndexesFromModule(previousModel);
+        HashMap<String, List<Index>> currentUniqueIndexes = getUniqueIndexesFromModule(currentModel);
+        processIndexDifferences(previousUniqueIndexes, currentUniqueIndexes, migrationDataHolder);
+
         // Convert differences to queries (ordered)
         addDropTableQueries(migrationDataHolder.getRemovedEntities(), queries);
         addDropForeignKeyQueries(migrationDataHolder.getRemovedForeignKeys(), queries);
@@ -535,10 +545,67 @@ public class Migrate implements BLauncherCmd {
                 migrationDataHolder.getAddedEntities(), currentModel, queries);
         addCreateForeignKeyQueries(migrationDataHolder.getAddedForeignKeys(), queries);
         addModifyColumnTypeQueries(migrationDataHolder.getChangedFieldTypes(), queries);
-
+        addDropIndexQueries(migrationDataHolder.getRemovedIndexes(), queries);
+        addCreateIndexQueries(migrationDataHolder.getAddedIndexes(), queries);
         printDetailedListOfDifferences(migrationDataHolder.getDifferences());
 
         return queries;
+    }
+
+    private static void processIndexDifferences(HashMap<String, List<Index>> previousIndexes,
+                                                HashMap<String, List<Index>> currentIndexes,
+                                                MigrationDataHolder migrationDataHolder) {
+        for (Map.Entry<String, List<Index>> entry : previousIndexes.entrySet()) {
+            if (migrationDataHolder.getRemovedEntities().contains(entry.getKey())) {
+                continue;
+            }
+            List<Index> previousIndexList = entry.getValue();
+            List<Index> currentIndexList = currentIndexes.get(entry.getKey());
+            // if all the indexes are removed from the entity
+            if (Objects.isNull(currentIndexList)) {
+                for (Index index : previousIndexList) {
+                    migrationDataHolder.removeIndex(entry.getKey(), index);
+                }
+                continue;
+            }
+            for (Index previousIndex : previousIndexList) {
+                boolean isIndexFound = false;
+                for (Index currentIndex : currentIndexList) {
+                    if (previousIndex.getIndexName().equals(currentIndex.getIndexName())) {
+                        isIndexFound = true;
+                        // Check if the fields are changed
+                        if (!Objects.equals(currentIndex.getFields().size(), previousIndex.getFields().size())) {
+                            migrationDataHolder.removeIndex(entry.getKey(), previousIndex);
+                            migrationDataHolder.addIndex(entry.getKey(), currentIndex);
+                        } else {
+                            for (int i = 0; i < currentIndex.getFields().size(); i++) {
+                                if (!currentIndex.getFields().get(i).getFieldName()
+                                        .equals(previousIndex.getFields().get(i).getFieldName())) {
+                                    migrationDataHolder.removeIndex(entry.getKey(), previousIndex);
+                                    migrationDataHolder.addIndex(entry.getKey(), currentIndex);
+                                    break;
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+                // Remove indexes that are not found in the current model
+                if (!isIndexFound) {
+                    migrationDataHolder.removeIndex(entry.getKey(), previousIndex);
+                }
+            }
+        }
+        // Add new indexes
+        for (Map.Entry<String, List<Index>> entry : currentIndexes.entrySet()) {
+            String entity = entry.getKey();
+            for (Index index : entry.getValue()) {
+                if (previousIndexes.get(entity) == null || previousIndexes.get(entity).stream()
+                        .noneMatch(previousIndex -> previousIndex.getIndexName().equals(index.getIndexName()))) {
+                    migrationDataHolder.addIndex(entity, index);
+                }
+            }
+        }
     }
 
     private static boolean isOnlyColumnsRenamed(List<Relation.Key> previousKeys, List<Relation.Key> currentKeys) {
@@ -561,6 +628,28 @@ public class Migrate implements BLauncherCmd {
         } else {
             errStream.println("-- No differences found" + System.lineSeparator());
         }
+    }
+
+    private static HashMap<String, List<Index>> getIndexesFromModule(Module module) {
+        HashMap<String, List<Index>> indexMap = new HashMap<>();
+        for (Entity entity : module.getEntityMap().values()) {
+            if (entity.getIndexes().isEmpty()) {
+                continue;
+            }
+            indexMap.put(entity.getTableName(), entity.getIndexes());
+        }
+        return indexMap;
+    }
+
+    private static HashMap<String, List<Index>> getUniqueIndexesFromModule(Module module) {
+        HashMap<String, List<Index>> indexMap = new HashMap<>();
+        for (Entity entity : module.getEntityMap().values()) {
+            if (entity.getUniqueIndexes().isEmpty()) {
+                continue;
+            }
+            indexMap.put(entity.getTableName(), entity.getUniqueIndexes());
+        }
+        return indexMap;
     }
 
     private static void addRenameFieldQueries(HashMap<String, List<MigrationDataHolder.NameMapping>> renamedFields,
@@ -709,6 +798,28 @@ public class Migrate implements BLauncherCmd {
                         foreignKey.columnNames().stream().reduce((a, b) -> a + ", " + b).orElse(""),
                         foreignKey.referenceTable(),
                         foreignKey.referenceColumns().stream().reduce((a, b) -> a + ", " + b).orElse("")));
+            }
+        }
+    }
+
+    private static void addCreateIndexQueries(Map<String, List<Index>> map, List<String> queries) {
+        String addIndexTemplate = "CREATE%s INDEX %s ON %s(%s);%n";
+        for (Map.Entry<String, List<Index>> entry : map.entrySet()) {
+            String entity = entry.getKey();
+            for (Index index : entry.getValue()) {
+                queries.add(String.format(addIndexTemplate, index.isUnique() ? " UNIQUE" : "", index.getIndexName(),
+                        entity, index.getFields().stream().map(EntityField::getFieldColumnName)
+                                .reduce((a, b) -> a + ", " + b).orElse("")));
+            }
+        }
+    }
+
+    private static void addDropIndexQueries(Map<String, List<Index>> map, List<String> queries) {
+        String dropIndexTemplate = "DROP INDEX %s ON %s;%n";
+        for (Map.Entry<String, List<Index>> entry : map.entrySet()) {
+            String entity = entry.getKey();
+            for (Index index : entry.getValue()) {
+                queries.add(String.format(dropIndexTemplate, index.getIndexName(), entity));
             }
         }
     }

--- a/persist-cli/src/main/java/io/ballerina/persist/models/MigrationDataHolder.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/models/MigrationDataHolder.java
@@ -33,16 +33,16 @@ public class MigrationDataHolder {
     private final List<String> addedEntities = new ArrayList<>();
     private final List<NameMapping> renamedEntities = new ArrayList<>();
     private final List<String> removedEntities = new ArrayList<>();
-    private final HashMap<String, List<EntityField>> addedFields = new HashMap<>();
-    private final HashMap<String, List<NameMapping>> renamedFields = new HashMap<>();
-    private final HashMap<String, List<String>> removedFields = new HashMap<>();
-    private final HashMap<String, List<EntityField>> changedFieldTypes = new HashMap<>();
+    private final Map<String, List<EntityField>> addedFields = new HashMap<>();
+    private final Map<String, List<NameMapping>> renamedFields = new HashMap<>();
+    private final Map<String, List<String>> removedFields = new HashMap<>();
+    private final Map<String, List<EntityField>> changedFieldTypes = new HashMap<>();
     private final Set<String> primaryKeyChangedEntities = new HashSet<>();
-    private final HashMap<String, List<ForeignKey>> addedForeignKeys = new HashMap<>();
-    private final HashMap<String, List<ForeignKey>> removedForeignKeys = new HashMap<>();
+    private final Map<String, List<ForeignKey>> addedForeignKeys = new HashMap<>();
+    private final Map<String, List<ForeignKey>> removedForeignKeys = new HashMap<>();
     private final List<String> differences = new ArrayList<>();
-    private final HashMap<String, List<Index>> addedIndexes = new HashMap<>();
-    private final HashMap<String, List<Index>> removedIndexes = new HashMap<>();
+    private final Map<String, List<Index>> addedIndexes = new HashMap<>();
+    private final Map<String, List<Index>> removedIndexes = new HashMap<>();
     public record NameMapping(String oldName, String newName) { }
 
     public void addTable(String tableName) {
@@ -85,7 +85,7 @@ public class MigrationDataHolder {
         addOrModifyColumn(tableName, currentModelField, changedFieldTypes);
     }
 
-    private void addOrModifyColumn(String tableName, EntityField field, HashMap<String, List<EntityField>> fieldMap) {
+    private void addOrModifyColumn(String tableName, EntityField field, Map<String, List<EntityField>> fieldMap) {
         if (!fieldMap.containsKey(tableName)) {
             List<EntityField> initialData = new ArrayList<>();
             initialData.add(field);
@@ -227,19 +227,19 @@ public class MigrationDataHolder {
         return removedEntities;
     }
 
-    public HashMap<String, List<EntityField>> getAddedFields() {
+    public Map<String, List<EntityField>> getAddedFields() {
         return addedFields;
     }
 
-    public HashMap<String, List<NameMapping>> getRenamedFields() {
+    public Map<String, List<NameMapping>> getRenamedFields() {
         return renamedFields;
     }
 
-    public HashMap<String, List<String>> getRemovedFields() {
+    public Map<String, List<String>> getRemovedFields() {
         return removedFields;
     }
 
-    public HashMap<String, List<EntityField>> getChangedFieldTypes() {
+    public Map<String, List<EntityField>> getChangedFieldTypes() {
         return changedFieldTypes;
     }
 
@@ -247,11 +247,11 @@ public class MigrationDataHolder {
         return primaryKeyChangedEntities;
     }
 
-    public HashMap<String, List<ForeignKey>> getAddedForeignKeys() {
+    public Map<String, List<ForeignKey>> getAddedForeignKeys() {
         return addedForeignKeys;
     }
 
-    public HashMap<String, List<ForeignKey>> getRemovedForeignKeys() {
+    public Map<String, List<ForeignKey>> getRemovedForeignKeys() {
         return removedForeignKeys;
     }
 
@@ -259,11 +259,11 @@ public class MigrationDataHolder {
         return differences;
     }
 
-    public HashMap<String, List<Index>> getAddedIndexes() {
+    public Map<String, List<Index>> getAddedIndexes() {
         return addedIndexes;
     }
 
-    public HashMap<String, List<Index>> getRemovedIndexes() {
+    public Map<String, List<Index>> getRemovedIndexes() {
         return removedIndexes;
     }
 }


### PR DESCRIPTION
## Purpose
This PR adds `bal persist migrate` support for changes to `@sql:Index` and `@sql:UniqueIndex` annotations. This PR completes the task mentioned below as well.

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/6189

## Checklist
- [X] Linked to an issue
- [x] Updated the specification
- [x] Updated the changelog
- [X] Added tests
