### PR TITLE
Fix recreation of `@sql:Name` annotated tables in `migrate` command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [Refactor migrate command and test cases to support more scenarios](https://github.com/ballerina-platform/ballerina-library/issues/6189)
+- [Fix a bug in the `migrate` command where tables with `@sql:Name` annotations are recreated](https://github.com/ballerina-platform/ballerina-library/issues/6374)
 
 ### Added
 - [Added support for PostgreSQL as a datasource](https://github.com/ballerina-platform/ballerina-standard-library/issues/5829)

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_25/persist/migrations/20240401112015_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_25/persist/migrations/20240401112015_firstMigration/model.bal
@@ -80,3 +80,14 @@ public type Test7 record {|
     float salary;
     boolean isEmployed;
 |};
+
+@sql:Name {value: "test_8"}
+public type Test8 record {|
+    readonly string nic;
+    @sql:Name {value: "user_name"}
+    string name;
+    @sql:Name {value: "user_age"}
+    int age;
+    float salary;
+    boolean isEmployed;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_25/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/input/tool_test_migrate_25/persist/model.bal
@@ -81,3 +81,14 @@ public type Test6 record {|
     float salary;
     boolean isEmployed;
 |};
+
+@sql:Name {value: "test_8"}
+public type Test8 record {|
+    readonly string nic;
+    @sql:Name {value: "user_name"}
+    string name;
+    @sql:Name {value: "user_age"}
+    int age;
+    float salary;
+    boolean isEmployed;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_25/persist/migrations/20240401112015_firstMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_25/persist/migrations/20240401112015_firstMigration/model.bal
@@ -80,3 +80,14 @@ public type Test7 record {|
     float salary;
     boolean isEmployed;
 |};
+
+@sql:Name {value: "test_8"}
+public type Test8 record {|
+    readonly string nic;
+    @sql:Name {value: "user_name"}
+    string name;
+    @sql:Name {value: "user_age"}
+    int age;
+    float salary;
+    boolean isEmployed;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_25/persist/migrations/20240403074452_secondMigration/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_25/persist/migrations/20240403074452_secondMigration/model.bal
@@ -81,3 +81,14 @@ public type Test6 record {|
     float salary;
     boolean isEmployed;
 |};
+
+@sql:Name {value: "test_8"}
+public type Test8 record {|
+    readonly string nic;
+    @sql:Name {value: "user_name"}
+    string name;
+    @sql:Name {value: "user_age"}
+    int age;
+    float salary;
+    boolean isEmployed;
+|};

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_25/persist/model.bal
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_migrate_25/persist/model.bal
@@ -81,3 +81,14 @@ public type Test6 record {|
     float salary;
     boolean isEmployed;
 |};
+
+@sql:Name {value: "test_8"}
+public type Test8 record {|
+    readonly string nic;
+    @sql:Name {value: "user_name"}
+    string name;
+    @sql:Name {value: "user_age"}
+    int age;
+    float salary;
+    boolean isEmployed;
+|};

--- a/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
+++ b/persist-cli/src/main/java/io/ballerina/persist/cmd/Migrate.java
@@ -515,7 +515,7 @@ public class Migrate implements BLauncherCmd {
 
         // Check for added entities
         for (Entity currentModelEntity : currentModel.getEntityMap().values()) {
-            Entity previousModelEntity = previousModel.getEntityMap().get(currentModelEntity.getTableName());
+            Entity previousModelEntity = previousModel.getEntityMap().get(currentModelEntity.getEntityName());
             if (previousModelEntity == null &&
                     !migrationDataHolder.isEntityRenamed(currentModelEntity.getTableName())) {
                 migrationDataHolder.addTable(currentModelEntity.getTableName());


### PR DESCRIPTION
## Purpose

Fixes: 
- [/ballerina-platform/ballerina-library/issues/6374](https://github.com/ballerina-platform/ballerina-library/issues/6374)

## Examples

## Checklist
- [X] Linked to an issue
- [ ] Updated the specification
- [X] Updated the changelog
- [X] Added tests
