### PR TITLE
Set offline mode to false to enable dependency fetching for model files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ This file contains all the notable changes done to the Ballerina Persist Tools t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.9.0] - 2026-02-24
 
 ### Added
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,10 +49,10 @@ stdlibHttpVersion=2.14.0
 stdlibSqlVersion=1.16.0
 
 # Level 09
-stdlibPersistVersion=1.7.0-20260212-165200-cc05abc
+stdlibPersistVersion=1.7.0
 
 # Level 10
-stdlibPersistSqlVersion=1.7.2-20260223-082800-6b94b8c
+stdlibPersistSqlVersion=1.7.2
 stdlibPersistInmemoryVersion=1.6.0
 stdlibPersistGoogleSheetVersion=1.6.0
 stdlibPersistRedisVersion=0.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ stdlibPersistGoogleSheetVersion=1.6.0
 stdlibPersistRedisVersion=0.4.0
 
 # Persist native jar maven dependencies
-persistSqlNativeVersion=1.7.2-20260223-082800-6b94b8c
+persistSqlNativeVersion=1.7.2
 persistInMemoryNativeVersion=1.6.0
 persistGoogleSheetsNativeVersion=1.6.0
 persistRedisNativeVersion=0.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina
-version=1.9.0
+version=1.9.1-SNAPSHOT
 
 # Java Dependencies
 ballerinaLangVersion=2201.13.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina
-version=1.9.0-SNAPSHOT
+version=1.9.0
 
 # Java Dependencies
 ballerinaLangVersion=2201.13.0

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_1/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_1/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_1/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_1/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_101/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_105/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_105/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_105/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_105/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_106/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_106/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_106/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_106/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_107_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_107_h2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_107_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_107_h2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_108_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_108_h2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_108_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_108_h2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_109_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_109_h2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_109_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_109_h2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_11/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_11/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_11/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_11/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_110_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_110_h2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_110_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_110_h2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_111_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_111_h2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_111_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_111_h2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_112_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_112_h2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_112_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_112_h2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_113_schema/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_113_schema/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_113_schema/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_113_schema/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_114/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_114/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_114/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_114/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_115/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_115/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_115/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_115/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_116/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_116/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_116/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_116/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_117/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_117/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_117/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_117/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_118_init_params_mysql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_118_init_params_mysql/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_118_init_params_mysql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_118_init_params_mysql/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_119_init_params_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_119_init_params_postgresql/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_119_init_params_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_119_init_params_postgresql/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_12/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_12/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_12/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_12/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_120_init_params_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_120_init_params_mssql/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_120_init_params_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_120_init_params_mssql/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_121_init_params_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_121_init_params_h2/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_121_init_params_h2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_121_init_params_h2/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_122_init_params_relationships/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_122_init_params_relationships/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_122_init_params_relationships/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_122_init_params_relationships/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_123_init_params_multiple_entities/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_123_init_params_multiple_entities/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_123_init_params_multiple_entities/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_123_init_params_multiple_entities/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_124_init_params_with_config/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_124_init_params_with_config/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_124_init_params_with_config/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_124_init_params_with_config/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_125_init_params_negative_invalid_model/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_125_init_params_negative_invalid_model/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_125_init_params_negative_invalid_model/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_125_init_params_negative_invalid_model/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.13.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_13/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_13/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_13/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_13/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_15/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_15/Ballerina.toml
@@ -20,4 +20,4 @@ targetModule = "persist_generate_15.entities"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_15/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_15/Ballerina.toml
@@ -20,4 +20,4 @@ targetModule = "persist_generate_15.entities"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_16/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_16/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_16/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_16/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_17/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_17/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_17/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_17/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_19/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_19/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_19/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_19/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_22/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_22/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_22/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_22/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_24/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_24/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_24/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_24/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_25/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_25/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_25/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_25/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_26/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_26/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_26/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_26/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_27/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_27/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_27/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_27/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_28/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_28/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_28/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_28/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_29/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_29/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_29/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_29/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_3/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_3/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_3/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_3/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_31/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_31/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.3.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_31/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_31/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.3.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_33/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_33/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.3.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_33/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_33/Ballerina.toml
@@ -7,5 +7,5 @@ distribution = "2201.3.0"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_34/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_34/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_34/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_34/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_35/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_35/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_35/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_35/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_36/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_36/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_36/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_36/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_37/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_37/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_37/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_37/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_39/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_39/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_39/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_39/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_40/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_40/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_40/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_40/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_41/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_41/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_41/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_41/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_46/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_46/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_46/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_46/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_5/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_5/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_5/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_5/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_50/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_50/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_50/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_50/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_51/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_51/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_51/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_51/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_58_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_58_mssql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_58_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_58_mssql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_59_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_59_mssql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_59_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_59_mssql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_60_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_60_mssql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_60_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_60_mssql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_61_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_61_mssql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_61_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_61_mssql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_62_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_62_mssql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_62_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_62_mssql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_63_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_63_mssql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_63_mssql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_63_mssql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_64/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_64/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_64/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_64/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_65/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_65/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_65/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_65/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_66_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_66_postgresql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_66_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_66_postgresql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_67_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_67_postgresql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_67_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_67_postgresql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_68_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_68_postgresql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_68_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_68_postgresql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_69_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_69_postgresql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_69_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_69_postgresql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_7/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_7/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_7/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_7/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_70_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_70_postgresql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_70_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_70_postgresql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_71_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_71_postgresql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_71_postgresql/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_71_postgresql/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_72/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_73/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_74/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_75/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_76/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_77/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_78/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_79/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_8/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_8/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_8/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_8/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_80/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_81/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_82/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_83/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_84/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_85/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_86/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_87/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_88/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_89/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_9/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_9/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_9/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_9/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_90/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_91/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_92/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_93/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_94/Ballerina.toml
@@ -10,6 +10,6 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_backward_compat/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_backward_compat/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_backward_compat/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_backward_compat/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_hybrid/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_hybrid/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_hybrid/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_hybrid/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_1/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_1/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_1/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_1/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_2/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_2/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_3/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_3/Ballerina.toml
@@ -10,7 +10,7 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_3/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_3/Ballerina.toml
@@ -10,7 +10,7 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_4/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_4/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.2-20260223-082800-6b94b8c"
+version = "1.7.2"

--- a/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_4/Ballerina.toml
+++ b/persist-cli-tests/src/test/resources/test-src/output/tool_test_generate_multimodel_4/Ballerina.toml
@@ -10,4 +10,4 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.1"
+version = "1.7.2-20260223-082800-6b94b8c"

--- a/persist-core/src/main/java/io/ballerina/persist/utils/BalProjectUtils.java
+++ b/persist-core/src/main/java/io/ballerina/persist/utils/BalProjectUtils.java
@@ -165,7 +165,9 @@ public class BalProjectUtils {
 
     public static void validateSchemaFile(Path schemaPath, String modelFileName) throws BalException {
         BuildOptions.BuildOptionsBuilder buildOptionsBuilder = BuildOptions.builder();
-        buildOptionsBuilder.setOffline(true);
+        // Setting offline to `false` to allow fetching dependencies for the model
+        // file.
+        buildOptionsBuilder.setOffline(false);
         SingleFileProject buildProject = SingleFileProject.load(schemaPath.toAbsolutePath(),
                 buildOptionsBuilder.build());
         Package currentPackage = buildProject.currentPackage();

--- a/persist-tool/BalTool.toml
+++ b/persist-tool/BalTool.toml
@@ -2,7 +2,7 @@
 id = "persist"
 
 [[dependency]]
-path = "../persist-cli/build/libs/persist-cli-1.9.0-SNAPSHOT.jar"
+path = "../persist-cli/build/libs/persist-cli-1.9.0.jar"
 
 [[dependency]]
-path = "../persist-core/build/libs/persist-core-1.9.0-SNAPSHOT.jar"
+path = "../persist-core/build/libs/persist-core-1.9.0.jar"


### PR DESCRIPTION
## Purpose

> $Subject

## Examples

N/A

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the specification~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary of Changes

This pull request enables dependency fetching for model file processing and updates project dependencies to improve stability and consistency.

### Core Functionality Change
- Modified the offline mode flag from true to false in `BalProjectUtils.java` to allow dependencies to be fetched during model file schema validation, enabling the tool to properly resolve and access model file dependencies.

### Dependency Version Updates
- Updated `persist.sql-native` dependency version from 1.7.1 to 1.7.2 across all test resource Ballerina.toml files (60+ files)
- Normalized dependency version declarations in `gradle.properties` by removing timestamp suffixes for consistency:
  - `stdlibPersistVersion`: 1.7.0 (removed timestamp suffix)
  - `stdlibPersistSqlVersion`: 1.7.2 (removed timestamp suffix)
  - `persistSqlNativeVersion`: 1.7.2 (removed timestamp suffix)

### Release Updates
- Bumped project version from 1.9.0-SNAPSHOT to 1.9.1-SNAPSHOT in gradle.properties
- Updated changelog to mark version 1.9.0 as released with date 2026-02-24
- Updated tool configuration references in BalTool.toml to reference non-SNAPSHOT artifacts

### Impact
The primary change enables the tool to fetch and resolve dependencies when processing model files, which improves the reliability of schema validation and model file handling by ensuring all required dependencies are available during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->